### PR TITLE
[fix] Tweak removeListener to correctly handle the once argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -166,9 +166,11 @@ EventEmitter.prototype.removeListener = function removeListener(event, fn, once)
     , events = [];
 
   if (fn) {
-    if (listeners.fn && listeners.fn !== fn) events.push(listeners);
+    if (listeners.fn && (listeners.fn !== fn || (once && !listeners.once))) {
+      events.push(listeners);
+    }
     if (!listeners.fn) for (var i = 0, length = listeners.length; i < length; i++) {
-      if (listeners[i].fn !== fn && listeners[i].once !== once) {
+      if (listeners[i].fn !== fn || (once && !listeners[i].once)) {
         events.push(listeners[i]);
       }
     }

--- a/test/emitter.test.js
+++ b/test/emitter.test.js
@@ -246,6 +246,33 @@ describe('EventEmitter', function tests() {
       expect(e.removeListener('bar')).to.equal(e);
       expect(e.listeners('bar').length).to.equal(0);
     });
+
+    it('should only remove once events when using the once flag', function () {
+      var e = new EventEmitter();
+
+      function foo() {}
+      e.on('foo', foo);
+
+      expect(e.removeListener('foo', function () {}, true)).to.equal(e);
+      expect(e.listeners('foo').length).to.equal(1);
+      expect(e.removeListener('foo', foo, true)).to.equal(e);
+      expect(e.listeners('foo').length).to.equal(1);
+      expect(e.removeListener('foo', foo)).to.equal(e);
+      expect(e.listeners('foo').length).to.equal(0);
+
+      e.on('foo', foo);
+      e.once('foo', foo);
+
+      expect(e.removeListener('foo', function () {}, true)).to.equal(e);
+      expect(e.listeners('foo').length).to.equal(2);
+      expect(e.removeListener('foo', foo, true)).to.equal(e);
+      expect(e.listeners('foo').length).to.equal(1);
+
+      e.once('foo', foo);
+
+      expect(e.removeListener('foo', foo)).to.equal(e);
+      expect(e.listeners('foo').length).to.equal(0);
+    });
   });
 
   describe('EventEmitter#removeAllListeners', function () {


### PR DESCRIPTION
This fixes a bug where events could be incorrectly removed when using the once flag.
For example the following snippet

``` js
var e = new EventEmitter();

function foo() {}
e.on('foo', foo);
e.once('foo', foo);

e.removeListener('foo', function () {}, true);
```

removes the one-time event even if the `listener` is not the same.
