### PR TITLE
[fix] Use the correct event in the listeners benchmark

### DIFF
--- a/benchmarks/run/listeners.js
+++ b/benchmarks/run/listeners.js
@@ -39,18 +39,18 @@ for (var i = 0; i < 25; i++) {
 
 //
 // EE2 doesn't correctly handle listeners as they can be removed by doing a
-// ee2.listeners('foo').length = 0; kills the event emitter, same counts for
+// ee2.listeners('event').length = 0; kills the event emitter, same counts for
 // Drip
 //
 
 (
   new benchmark.Suite()
 ).add('EventEmitter 1', function test1() {
-  ee1.listeners('foo');
+  ee1.listeners('event');
 }).add('EventEmitter 3', function test2() {
-  ee3.listeners('foo');
+  ee3.listeners('event');
 }).add('EventEmitter 3 (master)', function test2() {
-  master.listeners('foo');
+  master.listeners('event');
 }).on('cycle', function cycle(e) {
   var details = e.target;
 


### PR DESCRIPTION
I was surprised to see that `EventEmitter3` was the fastest in this benchmark mostly because i saw that the listeners are returned after looping through all the `EE` objects and after building a new array.

This fixes the benchmark using the correct event.
