### PR TITLE
[minor] Remove unneeded microtime dependency

### DIFF
--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -9,9 +9,8 @@
   "author": "",
   "license": "BSD",
   "dependencies": {
-    "benchmark": "~1.0.0",
+    "benchmark": "1.0.x",
     "devnull": "0.0.10",
-    "microtime": "~0.4.0",
     "eventemitter2": "*",
     "eventemitter3": "*",
     "drip": "*"

--- a/benchmarks/run/context.js
+++ b/benchmarks/run/context.js
@@ -3,8 +3,7 @@
 /**
  * Benchmark related modules.
  */
-var benchmark = require('benchmark')
-  , microtime = require('microtime');
+var benchmark = require('benchmark');
 
 /**
  * Logger.

--- a/benchmarks/run/emit.js
+++ b/benchmarks/run/emit.js
@@ -3,8 +3,7 @@
 /**
  * Benchmark related modules.
  */
-var benchmark = require('benchmark')
-  , microtime = require('microtime');
+var benchmark = require('benchmark');
 
 /**
  * Logger.

--- a/benchmarks/run/hundreds.js
+++ b/benchmarks/run/hundreds.js
@@ -3,11 +3,10 @@
 /**
  * Benchmark related modules.
  */
-var benchmark = require('benchmark')
-  , microtime = require('microtime');
+var benchmark = require('benchmark');
 
 /**
- * Logger
+ * Logger.
  */
 var logger = new(require('devnull'))({ timestamp: false, namespacing: 0 });
 

--- a/benchmarks/run/init.js
+++ b/benchmarks/run/init.js
@@ -3,8 +3,7 @@
 /**
  * Benchmark related modules.
  */
-var benchmark = require('benchmark')
-  , microtime = require('microtime');
+var benchmark = require('benchmark');
 
 /**
  * Logger.

--- a/benchmarks/run/listeners.js
+++ b/benchmarks/run/listeners.js
@@ -3,8 +3,7 @@
 /**
  * Benchmark related modules.
  */
-var benchmark = require('benchmark')
-  , microtime = require('microtime');
+var benchmark = require('benchmark');
 
 /**
  * Logger.

--- a/benchmarks/run/listening.js
+++ b/benchmarks/run/listening.js
@@ -3,8 +3,7 @@
 /**
  * Benchmark related modules.
  */
-var benchmark = require('benchmark')
-  , microtime = require('microtime');
+var benchmark = require('benchmark');
 
 /**
  * Logger.

--- a/benchmarks/run/multiple-emitters.js
+++ b/benchmarks/run/multiple-emitters.js
@@ -3,8 +3,7 @@
 /**
  * Benchmark related modules.
  */
-var benchmark = require('benchmark')
-  , microtime = require('microtime');
+var benchmark = require('benchmark');
 
 /**
  * Logger.

--- a/benchmarks/run/once.js
+++ b/benchmarks/run/once.js
@@ -3,8 +3,7 @@
 /**
  * Benchmark related modules.
  */
-var benchmark = require('benchmark')
-  , microtime = require('microtime');
+var benchmark = require('benchmark');
 
 /**
  * Logger.

--- a/benchmarks/template.js
+++ b/benchmarks/template.js
@@ -3,11 +3,10 @@
 /**
  * Benchmark related modules.
  */
-var benchmark = require('benchmark')
-  , microtime = require('microtime');
+var benchmark = require('benchmark');
 
 /**
- * Logger
+ * Logger.
  */
 var logger = new(require('devnull'))({ timestamp: false, namespacing: 0 });
 
@@ -32,7 +31,7 @@ var logger = new(require('devnull'))({ timestamp: false, namespacing: 0 });
     , details.hz
   );
 }).on('complete', function completed() {
-  logger.info('Benchmark: "%s" is was the fastest.'
+  logger.info('Benchmark: "%s" is the fastest.'
     , this.filter('fastest').pluck('name')
   );
 }).run();


### PR DESCRIPTION
This removes the `microtime` dependency.
It's optional and from what i saw the benchmark library builds different results and uses the one with the highest resolution. In Node.js >= 0.8 it tries to use `process.hrtime()` https://github.com/bestiejs/benchmark.js/blob/f090d93cef4604cd66de64c5dd91dfd010dc0ec5/benchmark.js#L1843-L1845 and this should be the best result.
