### PR TITLE
[major] Allow listeners to be removed by context. #24

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ EventEmitter.prototype.emit = function emit(event, a1, a2, a3, a4, a5) {
     , i;
 
   if ('function' === typeof listeners.fn) {
-    if (listeners.once) this.removeListener(event, listeners.fn, true);
+    if (listeners.once) this.removeListener(event, listeners.fn, undefined, true);
 
     switch (len) {
       case 1: return listeners.fn.call(listeners.context), true;
@@ -90,7 +90,7 @@ EventEmitter.prototype.emit = function emit(event, a1, a2, a3, a4, a5) {
       , j;
 
     for (i = 0; i < length; i++) {
-      if (listeners[i].once) this.removeListener(event, listeners[i].fn, true);
+      if (listeners[i].once) this.removeListener(event, listeners[i].fn, undefined, true);
 
       switch (len) {
         case 1: listeners[i].fn.call(listeners[i].context); break;
@@ -162,10 +162,11 @@ EventEmitter.prototype.once = function once(event, fn, context) {
  *
  * @param {String} event The event we want to remove.
  * @param {Function} fn The listener that we need to find.
+ * @param {Mixed} context Only remove listeners matching this context.
  * @param {Boolean} once Only remove once listeners.
  * @api public
  */
-EventEmitter.prototype.removeListener = function removeListener(event, fn, once) {
+EventEmitter.prototype.removeListener = function removeListener(event, fn, context, once) {
   var prefix = '~'+ event;
 
   if (!this._events || !this._events[prefix]) return this;
@@ -178,7 +179,11 @@ EventEmitter.prototype.removeListener = function removeListener(event, fn, once)
       events.push(listeners);
     }
     if (!listeners.fn) for (var i = 0, length = listeners.length; i < length; i++) {
-      if (listeners[i].fn !== fn || (once && !listeners[i].once)) {
+      if (
+           listeners[i].fn !== fn
+        || (once && !listeners[i].once)
+        || (context && listeners[i].context !== context)
+      ) {
         events.push(listeners[i]);
       }
     }

--- a/test.js
+++ b/test.js
@@ -340,9 +340,9 @@ describe('EventEmitter', function tests() {
       function foo() {}
       e.on('foo', foo);
 
-      assume(e.removeListener('foo', function () {}, true)).equals(e);
+      assume(e.removeListener('foo', function () {}, undefined, true)).equals(e);
       assume(e.listeners('foo').length).equals(1);
-      assume(e.removeListener('foo', foo, true)).equals(e);
+      assume(e.removeListener('foo', foo, undefined, true)).equals(e);
       assume(e.listeners('foo').length).equals(1);
       assume(e.removeListener('foo', foo)).equals(e);
       assume(e.listeners('foo').length).equals(0);
@@ -350,14 +350,42 @@ describe('EventEmitter', function tests() {
       e.on('foo', foo);
       e.once('foo', foo);
 
-      assume(e.removeListener('foo', function () {}, true)).equals(e);
+      assume(e.removeListener('foo', function () {}, undefined, true)).equals(e);
       assume(e.listeners('foo').length).equals(2);
-      assume(e.removeListener('foo', foo, true)).equals(e);
+      assume(e.removeListener('foo', foo, undefined, true)).equals(e);
       assume(e.listeners('foo').length).equals(1);
 
       e.once('foo', foo);
 
       assume(e.removeListener('foo', foo)).equals(e);
+      assume(e.listeners('foo').length).equals(0);
+    });
+
+    it('should only remove listeners matching the correct context', function () {
+      var e = new EventEmitter()
+        , context = { foo: 'bar' };
+
+      function foo() {}
+      function bar() {}
+      e.on('foo', foo, context);
+
+      assume(e.listeners('foo').length).equals(1);
+      assume(e.removeListener('foo', function () {}, context)).equals(e);
+      assume(e.listeners('foo').length).equals(1);
+      assume(e.removeListener('foo', foo, context)).equals(e);
+      assume(e.listeners('foo').length).equals(0);
+
+      e.on('foo', foo, context);
+      e.on('foo', bar);
+
+      assume(e.listeners('foo').length).equals(2);
+      assume(e.removeListener('foo', foo, context)).equals(e);
+      assume(e.listeners('foo').length).equals(1);
+      assume(e.listeners('foo')[0]).equals(bar);
+
+      e.on('foo', foo, context);
+      e.removeAllListeners('foo');
+
       assume(e.listeners('foo').length).equals(0);
     });
   });


### PR DESCRIPTION
This introduces a new syntax, `removeListener(event, fn, context)` as public API. The previous API for removing once listeners as third argument was always undocumented and private. We should still bump a major version as this is still a breaking change.