### PR TITLE
Exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ slight differences:
 - No `setMaxListeners` and it's pointless memory leak warnings. If you want to
   add `end` listeners you should be able to do that without modules complaining.
 - No `listenerCount` function. Use `EE.listeners(event).length` instead.
+- Support for custom context for events so there is no more `fn.bind` required.
+- `listeners` method can now do existence checking instead returning full arrays
 
 It's a drop in replacement for existing EventEmitters, but just faster. Free
 performance, who wouldn't want that? The EventEmitter is written in EcmaScript 3
@@ -62,6 +64,22 @@ function emitted() {
 EE.once('event-name', emitted, context);
 EE.on('another-event', emitted, context);
 EE.removeListener('another-event', emitted, context);
+```
+
+### Existence
+
+To check if there is already a listener for a given event you can supply the
+`listeners` method with an extra boolean argument. This will transform the
+output from an array, to a boolean value which indicates if there are listeners
+in place for the given event:
+
+```js
+var EE = new EventEmitter();
+EE.once('event-name', function () {});
+EE.on('another-event', function () {});
+
+EE.listeners('event-name', true); // returns true
+EE.listeners('unknown-name', true); // returns false
 ```
 
 ## License

--- a/index.js
+++ b/index.js
@@ -35,13 +35,16 @@ EventEmitter.prototype._events = undefined;
  * Return a list of assigned event listeners.
  *
  * @param {String} event The events that should be listed.
- * @returns {Array}
+ * @param {Boolean} exists We only need to know if there are listeners.
+ * @returns {Array|Boolean}
  * @api public
  */
-EventEmitter.prototype.listeners = function listeners(event) {
-  var prefix = '~'+ event;
+EventEmitter.prototype.listeners = function listeners(event, exists) {
+  var prefix = '~'+ event
+    , available = this._events && this._events[prefix];
 
-  if (!this._events || !this._events[prefix]) return [];
+  if (exists) return !!available;
+  if (!available) return [];
   if (this._events[prefix].fn) return [this._events[prefix].fn];
 
   for (var i = 0, l = this._events[prefix].length, ee = new Array(l); i < l; i++) {

--- a/test.js
+++ b/test.js
@@ -233,6 +233,30 @@ describe('EventEmitter', function tests() {
       e.listeners('foo').length = 0;
       assume(e.listeners('foo')).deep.equals([foo]);
     });
+
+    it('can return a boolean as indication if listeners exist', function () {
+      var e = new EventEmitter();
+
+      function foo() {}
+
+      e.once('once', foo);
+      e.once('multiple', foo);
+      e.once('multiple', foo);
+      e.on('on', foo);
+      e.on('multi', foo);
+      e.on('multi', foo);
+
+      assume(e.listeners('foo', true)).is.false();
+      assume(e.listeners('multiple', true)).is.true();
+      assume(e.listeners('on', true)).is.true();
+      assume(e.listeners('multi', true)).is.true();
+
+      e.removeAllListeners();
+
+      assume(e.listeners('multiple', true)).is.false();
+      assume(e.listeners('on', true)).is.false();
+      assume(e.listeners('multi', true)).is.false();
+    });
   });
 
   describe('EventEmitter#once', function () {


### PR DESCRIPTION
Extend the `listener` method to only do existence checks. It's quite hard to this without touching internal api's and knowing how the keys are prefixed.