### PR TITLE
Fix contextual removal for events with only one listener

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js:
   - "0.8"
@@ -5,7 +6,7 @@ node_js:
   - "0.12"
   - "iojs"
 before_install:
-  - 'if [ "${TRAVIS_NODE_VERSION}" == "0.8" ] ; then npm install -g npm@2.5.1; fi'
+  - 'if [ "${TRAVIS_NODE_VERSION}" == "0.8" ] ; then npm install -g npm@2.7.3; fi'
 script:
   - "npm run test-travis"
 after_script:

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 [![Version npm](https://img.shields.io/npm/v/eventemitter3.svg?style=flat-square)](http://browsenpm.org/package/eventemitter3)[![Build Status](https://img.shields.io/travis/primus/eventemitter3/master.svg?style=flat-square)](https://travis-ci.org/primus/eventemitter3)[![Dependencies](https://img.shields.io/david/primus/eventemitter3.svg?style=flat-square)](https://david-dm.org/primus/eventemitter3)[![Coverage Status](https://img.shields.io/coveralls/primus/eventemitter3/master.svg?style=flat-square)](https://coveralls.io/r/primus/eventemitter3?branch=master)[![IRC channel](https://img.shields.io/badge/IRC-irc.freenode.net%23primus-00a8ff.svg?style=flat-square)](https://webchat.freenode.net/?channels=primus)
 
 EventEmitter3 is a high performance EventEmitter. It has been micro-optimized
-for various of code paths making this one of the, if not the fastest
-EventEmitter available for Node.js and browsers. The module is API compatible
-with the EventEmitter that ships by default within Node.js but there are some
-slight differences:
+for various of code paths making this, one of, if not the fastest EventEmitter
+available for Node.js and browsers. The module is API compatible with the
+EventEmitter that ships by default with Node.js but there are some slight
+differences:
 
 - Domain support has been removed.
 - We do not `throw` an error when you emit an `error` event and nobody is
@@ -16,8 +16,8 @@ slight differences:
 - No `setMaxListeners` and it's pointless memory leak warnings. If you want to
   add `end` listeners you should be able to do that without modules complaining.
 - No `listenerCount` function. Use `EE.listeners(event).length` instead.
-- Support for custom context for events so there is no more `fn.bind` required.
-- `listeners` method can now do existence checking instead returning full arrays
+- Support for custom context for events so there is no need to use `fn.bind`.
+- `listeners` method can do existence checking instead of returning only arrays.
 
 It's a drop in replacement for existing EventEmitters, but just faster. Free
 performance, who wouldn't want that? The EventEmitter is written in EcmaScript 3
@@ -84,4 +84,4 @@ EE.listeners('unknown-name', true); // returns false
 
 ## License
 
-MIT
+[MIT](LICENSE)

--- a/index.js
+++ b/index.js
@@ -178,16 +178,23 @@ EventEmitter.prototype.removeListener = function removeListener(event, fn, conte
     , events = [];
 
   if (fn) {
-    if (listeners.fn && (listeners.fn !== fn || (once && !listeners.once))) {
-      events.push(listeners);
-    }
-    if (!listeners.fn) for (var i = 0, length = listeners.length; i < length; i++) {
+    if (listeners.fn) {
       if (
-           listeners[i].fn !== fn
-        || (once && !listeners[i].once)
-        || (context && listeners[i].context !== context)
+           listeners.fn !== fn
+        || (once && !listeners.once)
+        || (context && listeners.context !== context)
       ) {
-        events.push(listeners[i]);
+        events.push(listeners);
+      }
+    } else {
+      for (var i = 0, length = listeners.length; i < length; i++) {
+        if (
+             listeners[i].fn !== fn
+          || (once && !listeners[i].once)
+          || (context && listeners[i].context !== context)
+        ) {
+          events.push(listeners[i]);
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eventemitter3",
-  "version": "0.1.6",
+  "version": "1.0.0",
   "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
   "main": "index.js",
   "scripts": {
@@ -35,9 +35,9 @@
     "url": "https://github.com/primus/EventEmitter3/issues"
   },
   "devDependencies": {
-    "assume": "1.1.x",
+    "assume": "1.2.x",
     "istanbul": "0.3.x",
-    "mocha": "2.1.x",
+    "mocha": "2.2.x",
     "pre-commit": "1.0.x"
   }
 }

--- a/test.js
+++ b/test.js
@@ -396,6 +396,8 @@ describe('EventEmitter', function tests() {
       assume(e.listeners('foo').length).equals(1);
       assume(e.removeListener('foo', function () {}, context)).equals(e);
       assume(e.listeners('foo').length).equals(1);
+      assume(e.removeListener('foo', foo, { baz: 'quux' })).equals(e);
+      assume(e.listeners('foo').length).equals(1);
       assume(e.removeListener('foo', foo, context)).equals(e);
       assume(e.listeners('foo').length).equals(0);
 
@@ -403,13 +405,16 @@ describe('EventEmitter', function tests() {
       e.on('foo', bar);
 
       assume(e.listeners('foo').length).equals(2);
+      assume(e.removeListener('foo', foo, { baz: 'quux' })).equals(e);
+      assume(e.listeners('foo').length).equals(2);
       assume(e.removeListener('foo', foo, context)).equals(e);
       assume(e.listeners('foo').length).equals(1);
       assume(e.listeners('foo')[0]).equals(bar);
 
       e.on('foo', foo, context);
-      e.removeAllListeners('foo');
 
+      assume(e.listeners('foo').length).equals(2);
+      assume(e.removeAllListeners('foo')).equals(e);
       assume(e.listeners('foo').length).equals(0);
     });
   });


### PR DESCRIPTION
This fixes this issue:
```js
var e = new EventEmitter()
  , context = { foo: 'bar' };

function foo() {}
e.on('foo', foo, context);

e.removeListener('foo', foo, { baz: 'quux' });

e.listeners('foo').length === 1 // false, but the context is different
```