### PR TITLE
update tests, and add contra.emitter

### DIFF
--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -14,7 +14,8 @@
     "drip": "*",
     "event-emitter": "*",
     "eventemitter2": "*",
-    "eventemitter3": "*",
-    "fastemitter": "*"
+    "eventemitter3": "0.1.6",
+    "fastemitter": "*",
+    "contra.emitter": "*"
   }
 }

--- a/benchmarks/run/context.js
+++ b/benchmarks/run/context.js
@@ -14,12 +14,13 @@ var logger = new(require('devnull'))({ timestamp: false, namespacing: 0 });
  * Preparation code.
  */
 var EventEmitter2 = require('eventemitter2').EventEmitter2
-  , EventEmitter3 = require('eventemitter3').EventEmitter
+  , EventEmitter3 = require('eventemitter3')
   , EventEmitter1 = require('events').EventEmitter
-  , Master = require('../../').EventEmitter
+  , Master = require('../../')
   , Drip = require('drip').EventEmitter
   , EE = require('event-emitter')
-  , FE = require('fastemitter');
+  , FE = require('fastemitter')
+  , CE = require('contra.emitter');
 
 function handle() {
   if (arguments.length > 100) console.log('damn');
@@ -34,7 +35,8 @@ var ee2 = new EventEmitter2()
   , master = new Master()
   , drip = new Drip()
   , fe = new FE()
-  , ee = EE({});
+  , ee = EE({})
+  , ce = CE();
 
 ee3.on('foo', handle, logger);
 ee2.on('foo', handle.bind(logger));
@@ -43,44 +45,50 @@ drip.on('foo', handle.bind(logger));
 master.on('foo', handle, logger);
 ee.on('foo', handle.bind(logger));
 fe.on('foo', handle.bind(logger));
+ce.on('foo', handle.bind(logger));
 
 (
   new benchmark.Suite()
-).add('EventEmitter 1', function test1() {
+).add('EventEmitter1', function() {
   ee1.emit('foo');
   ee1.emit('foo', 'bar');
   ee1.emit('foo', 'bar', 'baz');
   ee1.emit('foo', 'bar', 'baz', 'boom');
-}).add('EventEmitter 2', function test2() {
+}).add('EventEmitter2', function() {
   ee2.emit('foo');
   ee2.emit('foo', 'bar');
   ee2.emit('foo', 'bar', 'baz');
   ee2.emit('foo', 'bar', 'baz', 'boom');
-}).add('EventEmitter 3', function test2() {
+}).add('EventEmitter3@0.6.1', function() {
   ee3.emit('foo');
   ee3.emit('foo', 'bar');
   ee3.emit('foo', 'bar', 'baz');
   ee3.emit('foo', 'bar', 'baz', 'boom');
-}).add('EventEmitter 3 (master)', function test2() {
+}).add('EventEmitter3(master)', function() {
   master.emit('foo');
   master.emit('foo', 'bar');
   master.emit('foo', 'bar', 'baz');
   master.emit('foo', 'bar', 'baz', 'boom');
-}).add('Drip', function test2() {
+}).add('Drip', function() {
   drip.emit('foo');
   drip.emit('foo', 'bar');
   drip.emit('foo', 'bar', 'baz');
   drip.emit('foo', 'bar', 'baz', 'boom');
-}).add('fastemitter', function test2() {
+}).add('fastemitter', function() {
   fe.emit('foo');
   fe.emit('foo', 'bar');
   fe.emit('foo', 'bar', 'baz');
   fe.emit('foo', 'bar', 'baz', 'boom');
-}).add('event-emitter', function test2() {
+}).add('event-emitter', function() {
   ee.emit('foo');
   ee.emit('foo', 'bar');
   ee.emit('foo', 'bar', 'baz');
   ee.emit('foo', 'bar', 'baz', 'boom');
+}).add('contra.emitter', function() {
+  ce.emit('foo');
+  ce.emit('foo', 'bar');
+  ce.emit('foo', 'bar', 'baz');
+  ce.emit('foo', 'bar', 'baz', 'boom');
 }).on('cycle', function cycle(e) {
   var details = e.target;
 

--- a/benchmarks/run/emit.js
+++ b/benchmarks/run/emit.js
@@ -14,12 +14,13 @@ var logger = new(require('devnull'))({ timestamp: false, namespacing: 0 });
  * Preparation code.
  */
 var EventEmitter2 = require('eventemitter2').EventEmitter2
-  , EventEmitter3 = require('eventemitter3').EventEmitter
+  , EventEmitter3 = require('eventemitter3')
   , EventEmitter1 = require('events').EventEmitter
-  , Master = require('../../').EventEmitter
+  , Master = require('../../')
   , Drip = require('drip').EventEmitter
   , EE = require('event-emitter')
-  , FE = require('fastemitter');
+  , FE = require('fastemitter')
+  , CE = require('contra.emitter');
 
 function handle() {
   if (arguments.length > 100) console.log('damn');
@@ -34,7 +35,8 @@ var ee2 = new EventEmitter2()
   , master = new Master()
   , drip = new Drip()
   , fe = new FE()
-  , ee = EE({});
+  , ee = EE({})
+  , ce = CE();
 
 ee.on('foo', handle);
 fe.on('foo', handle);
@@ -43,44 +45,50 @@ ee2.on('foo', handle);
 ee1.on('foo', handle);
 drip.on('foo', handle);
 master.on('foo', handle);
+ce.on('foo', handle);
 
 (
   new benchmark.Suite()
-).add('EventEmitter 1', function test1() {
+).add('EventEmitter1', function() {
   ee1.emit('foo');
   ee1.emit('foo', 'bar');
   ee1.emit('foo', 'bar', 'baz');
   ee1.emit('foo', 'bar', 'baz', 'boom');
-}).add('EventEmitter 2', function test2() {
+}).add('EventEmitter2', function() {
   ee2.emit('foo');
   ee2.emit('foo', 'bar');
   ee2.emit('foo', 'bar', 'baz');
   ee2.emit('foo', 'bar', 'baz', 'boom');
-}).add('EventEmitter 3', function test2() {
+}).add('EventEmitter3@0.6.1', function() {
   ee3.emit('foo');
   ee3.emit('foo', 'bar');
   ee3.emit('foo', 'bar', 'baz');
   ee3.emit('foo', 'bar', 'baz', 'boom');
-}).add('EventEmitter 3 (master)', function test2() {
+}).add('EventEmitter3(master)', function() {
   master.emit('foo');
   master.emit('foo', 'bar');
   master.emit('foo', 'bar', 'baz');
   master.emit('foo', 'bar', 'baz', 'boom');
-}).add('Drip', function test2() {
+}).add('Drip', function() {
   drip.emit('foo');
   drip.emit('foo', 'bar');
   drip.emit('foo', 'bar', 'baz');
   drip.emit('foo', 'bar', 'baz', 'boom');
-}).add('fastemitter', function test2() {
+}).add('fastemitter', function() {
   fe.emit('foo');
   fe.emit('foo', 'bar');
   fe.emit('foo', 'bar', 'baz');
   fe.emit('foo', 'bar', 'baz', 'boom');
-}).add('event-emitter', function test2() {
+}).add('event-emitter', function() {
   ee.emit('foo');
   ee.emit('foo', 'bar');
   ee.emit('foo', 'bar', 'baz');
   ee.emit('foo', 'bar', 'baz', 'boom');
+}).add('contra.emitter', function() {
+  ce.emit('foo');
+  ce.emit('foo', 'bar');
+  ce.emit('foo', 'bar', 'baz');
+  ce.emit('foo', 'bar', 'baz', 'boom');
 }).on('cycle', function cycle(e) {
   var details = e.target;
 

--- a/benchmarks/run/hundreds.js
+++ b/benchmarks/run/hundreds.js
@@ -14,12 +14,13 @@ var logger = new(require('devnull'))({ timestamp: false, namespacing: 0 });
  * Preparation code.
  */
 var EventEmitter2 = require('eventemitter2').EventEmitter2
-  , EventEmitter3 = require('eventemitter3').EventEmitter
+  , EventEmitter3 = require('eventemitter3')
   , EventEmitter1 = require('events').EventEmitter
-  , Master = require('../../').EventEmitter
+  , Master = require('../../')
   , Drip = require('drip').EventEmitter
   , EE = require('event-emitter')
-  , FE = require('fastemitter');
+  , FE = require('fastemitter')
+  , CE = require('contra.emitter');
 
 function foo() {
   if (arguments.length > 100) console.log('damn');
@@ -37,10 +38,12 @@ var ee2 = new EventEmitter2()
   , drip = new Drip()
   , fe = new FE()
   , ee = EE({})
+  , ce = CE()
   , j, i;
 
 for (i = 0; i < 10; i++) {
   for (j = 0; j < 10; j++) {
+    ce.on('event:' + i, foo);
     ee.on('event:' + i, foo);
     fe.on('event:' + i, foo);
     ee1.on('event:' + i, foo);
@@ -53,33 +56,37 @@ for (i = 0; i < 10; i++) {
 
 (
   new benchmark.Suite()
-).add('EventEmitter 1', function test1() {
+).add('EventEmitter1', function() {
   for (i = 0; i < 10; i++) {
     ee1.emit('event:' + i);
   }
-}).add('EventEmitter 2', function test2() {
+}).add('EventEmitter2', function() {
   for (i = 0; i < 10; i++) {
     ee2.emit('event:' + i);
   }
-}).add('EventEmitter 3', function test2() {
+}).add('EventEmitter3@0.6.1', function() {
   for (i = 0; i < 10; i++) {
     ee3.emit('event:' + i);
   }
-}).add('EventEmitter 3 (master)', function test2() {
+}).add('EventEmitter3(master)', function() {
   for (i = 0; i < 10; i++) {
     master.emit('event:' + i);
   }
-}).add('Drip', function test2() {
+}).add('Drip', function() {
   for (i = 0; i < 10; i++) {
     drip.emit('event:' + i);
   }
-}).add('fastemitter', function test2() {
+}).add('fastemitter', function() {
   for (i = 0; i < 10; i++) {
     fe.emit('event:' + i);
   }
-}).add('event-emitter', function test2() {
+}).add('event-emitter', function() {
   for (i = 0; i < 10; i++) {
     ee.emit('event:' + i);
+  }
+}).add('contra.emitter', function() {
+  for (i = 0; i < 10; i++) {
+    ce.emit('event:' + i);
   }
 }).on('cycle', function cycle(e) {
   var details = e.target;

--- a/benchmarks/run/init.js
+++ b/benchmarks/run/init.js
@@ -14,29 +14,33 @@ var logger = new(require('devnull'))({ timestamp: false, namespacing: 0 });
  * Preparation code.
  */
 var EventEmitter2 = require('eventemitter2').EventEmitter2
-  , EventEmitter3 = require('eventemitter3').EventEmitter
+  , EventEmitter3 = require('eventemitter3')
   , EventEmitter1 = require('events').EventEmitter
-  , Master = require('../../').EventEmitter
+  , Master = require('../../')
   , Drip = require('drip').EventEmitter
   , EE = require('event-emitter')
-  , FE = require('fastemitter');
+  , FE = require('fastemitter')
+  , CE = require('contra.emitter');
+
 
 (
   new benchmark.Suite()
-).add('EventEmitter 1', function test1() {
-  var ee = new EventEmitter1();
-}).add('EventEmitter 2', function test2() {
-  var ee = new EventEmitter2();
-}).add('EventEmitter 3', function test3() {
-  var ee = new EventEmitter3();
-}).add('EventEmitter 3 (master)', function test3() {
-  var ee = new Master();
-}).add('Drip', function test3() {
+).add('EventEmitter1', function() {
+  var ee1 = new EventEmitter1();
+}).add('EventEmitter2', function() {
+  var ee2 = new EventEmitter2();
+}).add('EventEmitter3@0.6.1', function() {
+  var ee3 = new EventEmitter3();
+}).add('EventEmitter3(master)', function() {
+  var master = new Master();
+}).add('Drip', function() {
   var drip = new Drip();
-}).add('fastemitter', function test3() {
+}).add('fastemitter', function() {
   var fe = new FE();
-}).add('event-emitter', function test3() {
+}).add('event-emitter', function() {
   var ee = EE({});
+}).add('contra.emitter', function() {
+  var ce = CE();
 }).on('cycle', function cycle(e) {
   var details = e.target;
 

--- a/benchmarks/run/listeners.js
+++ b/benchmarks/run/listeners.js
@@ -13,10 +13,11 @@ var logger = new(require('devnull'))({ timestamp: false, namespacing: 0 });
 /**
  * Preparation code.
  */
-var EventEmitter3 = require('eventemitter3').EventEmitter
+var EventEmitter3 = require('eventemitter3')
   , EventEmitter1 = require('events').EventEmitter
-  , Master = require('../../').EventEmitter
+  , Master = require('../../')
   , FE = require('fastemitter');
+
 
 var MAX_LISTENERS = Math.pow(2, 32) - 1;
 
@@ -45,18 +46,19 @@ for (var i = 0; i < 25; i++) {
 //
 // EE2 doesn't correctly handle listeners as they can be removed by doing a
 // ee2.listeners('event').length = 0; kills the event emitter, same counts for
-// Drip. The event-emitter module doesn't even implement this.
+// Drip.
+// event-emitter and contra.emitter does not implement.
 //
 
 (
   new benchmark.Suite()
-).add('EventEmitter 1', function test1() {
+).add('EventEmitter1', function () {
   ee1.listeners('event');
-}).add('fastemitter', function test1() {
+}).add('fastemitter', function() {
   fe.listeners('event');
-}).add('EventEmitter 3', function test2() {
+}).add('EventEmitter3@0.6.1', function() {
   ee3.listeners('event');
-}).add('EventEmitter 3 (master)', function test2() {
+}).add('EventEmitter3(master)', function() {
   master.listeners('event');
 }).on('cycle', function cycle(e) {
   var details = e.target;

--- a/benchmarks/run/listening.js
+++ b/benchmarks/run/listening.js
@@ -14,12 +14,13 @@ var logger = new(require('devnull'))({ timestamp: false, namespacing: 0 });
  * Preparation code.
  */
 var EventEmitter2 = require('eventemitter2').EventEmitter2
-  , EventEmitter3 = require('eventemitter3').EventEmitter
+  , EventEmitter3 = require('eventemitter3')
   , EventEmitter1 = require('events').EventEmitter
-  , Master = require('../../').EventEmitter
+  , Master = require('../../')
   , Drip = require('drip').EventEmitter
   , EE = require('event-emitter')
-  , FE = require('fastemitter');
+  , FE = require('fastemitter')
+  , CE = require('contra.emitter');
 
 function handle() {
   if (arguments.length > 100) console.log('damn');
@@ -34,31 +35,35 @@ var ee2 = new EventEmitter2()
   , master = new Master()
   , drip = new Drip()
   , fe = new FE()
-  , ee = EE({});
+  , ee = EE({})
+  , ce = CE();
 
 (
   new benchmark.Suite()
-).add('EventEmitter 1', function test1() {
+).add('EventEmitter1', function() {
   ee1.on('foo', handle);
   ee1.removeListener('foo', handle);
-}).add('EventEmitter 2', function test2() {
+}).add('EventEmitter2', function() {
   ee2.on('foo', handle);
   ee2.removeListener('foo', handle);
-}).add('EventEmitter 3', function test2() {
+}).add('EventEmitter3@0.6.1', function() {
   ee3.on('foo', handle);
   ee3.removeListener('foo', handle);
-}).add('EventEmitter 3 (master)', function test2() {
+}).add('EventEmitter3(master)', function() {
   master.on('foo', handle);
   master.removeListener('foo', handle);
-}).add('Drip', function test2() {
+}).add('Drip', function() {
   drip.on('foo', handle);
   drip.removeListener('foo', handle);
-}).add('fastemitter', function test2() {
+}).add('fastemitter', function() {
   fe.on('foo', handle);
   fe.removeListener('foo', handle);
-}).add('event-emitter', function test2() {
+}).add('event-emitter', function() {
   ee.on('foo', handle);
   ee.off('foo', handle);
+}).add('contra.emitter', function() {
+  ce.on('foo', handle);
+  ce.off('foo', handle);
 }).on('cycle', function cycle(e) {
   var details = e.target;
 

--- a/benchmarks/run/multiple-emitters.js
+++ b/benchmarks/run/multiple-emitters.js
@@ -14,12 +14,14 @@ var logger = new(require('devnull'))({ timestamp: false, namespacing: 0 });
  * Preparation code.
  */
 var EventEmitter2 = require('eventemitter2').EventEmitter2
-  , EventEmitter3 = require('eventemitter3').EventEmitter
+  , EventEmitter3 = require('eventemitter3')
   , EventEmitter1 = require('events').EventEmitter
-  , Master = require('../../').EventEmitter
+  , Master = require('../../')
   , Drip = require('drip').EventEmitter
   , EE = require('event-emitter')
-  , FE = require('fastemitter');
+  , FE = require('fastemitter')
+  , CE = require('contra.emitter');
+
 
 function foo() {
   if (arguments.length > 100) console.log('damn');
@@ -48,8 +50,10 @@ var ee2 = new EventEmitter2()
   , master = new Master()
   , drip = new Drip()
   , fe = new FE()
-  , ee = EE({});
+  , ee = EE({})
+  , ce = CE();
 
+ce.on('foo', foo).on('foo', bar).on('foo', baz);
 ee.on('foo', foo).on('foo', bar).on('foo', baz);
 fe.on('foo', foo).on('foo', bar).on('foo', baz);
 ee3.on('foo', foo).on('foo', bar).on('foo', baz);
@@ -60,41 +64,46 @@ master.on('foo', foo).on('foo', bar).on('foo', baz);
 
 (
   new benchmark.Suite()
-).add('EventEmitter 1', function test1() {
+).add('EventEmitter1', function() {
   ee1.emit('foo');
   ee1.emit('foo', 'bar');
   ee1.emit('foo', 'bar', 'baz');
   ee1.emit('foo', 'bar', 'baz', 'boom');
-}).add('EventEmitter 2', function test2() {
+}).add('EventEmitter2', function() {
   ee2.emit('foo');
   ee2.emit('foo', 'bar');
   ee2.emit('foo', 'bar', 'baz');
   ee2.emit('foo', 'bar', 'baz', 'boom');
-}).add('EventEmitter 3', function test2() {
+}).add('EventEmitter3@0.6.1', function() {
   ee3.emit('foo');
   ee3.emit('foo', 'bar');
   ee3.emit('foo', 'bar', 'baz');
   ee3.emit('foo', 'bar', 'baz', 'boom');
-}).add('EventEmitter 3 (master)', function test2() {
+}).add('EventEmitter3(master)', function() {
   master.emit('foo');
   master.emit('foo', 'bar');
   master.emit('foo', 'bar', 'baz');
   master.emit('foo', 'bar', 'baz', 'boom');
-}).add('Drip', function test2() {
+}).add('Drip', function() {
   drip.emit('foo');
   drip.emit('foo', 'bar');
   drip.emit('foo', 'bar', 'baz');
   drip.emit('foo', 'bar', 'baz', 'boom');
-}).add('fastemitter', function test2() {
+}).add('fastemitter', function() {
   fe.emit('foo');
   fe.emit('foo', 'bar');
   fe.emit('foo', 'bar', 'baz');
   fe.emit('foo', 'bar', 'baz', 'boom');
-}).add('event-emitter', function test2() {
+}).add('event-emitter', function() {
   ee.emit('foo');
   ee.emit('foo', 'bar');
   ee.emit('foo', 'bar', 'baz');
   ee.emit('foo', 'bar', 'baz', 'boom');
+}).add('contra.emitter', function() {
+  ce.emit('foo');
+  ce.emit('foo', 'bar');
+  ce.emit('foo', 'bar', 'baz');
+  ce.emit('foo', 'bar', 'baz', 'boom');
 }).on('cycle', function cycle(e) {
   var details = e.target;
 

--- a/benchmarks/run/once.js
+++ b/benchmarks/run/once.js
@@ -14,12 +14,13 @@ var logger = new(require('devnull'))({ timestamp: false, namespacing: 0 });
  * Preparation code.
  */
 var EventEmitter2 = require('eventemitter2').EventEmitter2
-  , EventEmitter3 = require('eventemitter3').EventEmitter
+  , EventEmitter3 = require('eventemitter3')
   , EventEmitter1 = require('events').EventEmitter
-  , Master = require('../../').EventEmitter
+  , Master = require('../../')
   , Drip = require('drip').EventEmitter
   , EE = require('event-emitter')
-  , FE = require('fastemitter');
+  , FE = require('fastemitter')
+  , CE = require('contra.emitter');
 
 function handle() {
   if (arguments.length > 100) console.log('damn');
@@ -34,24 +35,27 @@ var ee2 = new EventEmitter2()
   , master = new Master()
   , drip = new Drip()
   , fe = new FE()
-  , ee = EE({});
+  , ee = EE({})
+  , ce = CE();
 
 (
   new benchmark.Suite()
-).add('EventEmitter 1', function test1() {
+).add('EventEmitter1', function() {
   ee1.once('foo', handle).emit('foo');
-}).add('EventEmitter 2', function test2() {
+}).add('EventEmitter2', function() {
   ee2.once('foo', handle).emit('foo');
-}).add('EventEmitter 3', function test2() {
+}).add('EventEmitter3@0.6.1', function() {
   ee3.once('foo', handle).emit('foo');
-}).add('EventEmitter 3 (master)', function test2() {
+}).add('EventEmitter3(master)', function() {
   master.once('foo', handle).emit('foo');
-}).add('Drip', function test2() {
+}).add('Drip', function() {
   drip.once('foo', handle).emit('foo');
-}).add('fastemitter', function test2() {
+}).add('fastemitter', function() {
   fe.once('foo', handle).emit('foo');
-}).add('event-emitter', function test2() {
+}).add('event-emitter', function() {
   ee.once('foo', handle).emit('foo');
+}).add('contra.emitter', function() {
+  ce.once('foo', handle).emit('foo');
 }).on('cycle', function cycle(e) {
   var details = e.target;
 

--- a/benchmarks/run/remove-emit.js
+++ b/benchmarks/run/remove-emit.js
@@ -14,12 +14,14 @@ var logger = new(require('devnull'))({ timestamp: false, namespacing: 0 });
  * Preparation code.
  */
 var EventEmitter2 = require('eventemitter2').EventEmitter2
-  , EventEmitter3 = require('eventemitter3').EventEmitter
+  , EventEmitter3 = require('eventemitter3')
   , EventEmitter1 = require('events').EventEmitter
-  , Master = require('../../').EventEmitter
+  , Master = require('../../')
   , Drip = require('drip').EventEmitter
   , EE = require('event-emitter')
-  , FE = require('fastemitter');
+  , FE = require('fastemitter')
+  , CE = require('contra.emitter');
+
 
 function handle() {
   if (arguments.length > 100) console.log('damn');
@@ -34,9 +36,10 @@ var ee2 = new EventEmitter2()
   , master = new Master()
   , drip = new Drip()
   , fe = new FE()
-  , ee = EE({});
+  , ee = EE({})
+  , ce = CE();
 
-[ee, ee3, ee2, ee1, fe, drip, master].forEach(function ohai(emitter) {
+[ce, ee, ee3, ee2, ee1, fe, drip, master].forEach(function ohai(emitter) {
   emitter.on('foo', handle);
 
   //
@@ -51,41 +54,46 @@ var ee2 = new EventEmitter2()
 
 (
   new benchmark.Suite()
-).add('EventEmitter 1', function test1() {
+).add('EventEmitter1', function() {
   ee1.emit('foo');
   ee1.emit('foo', 'bar');
   ee1.emit('foo', 'bar', 'baz');
   ee1.emit('foo', 'bar', 'baz', 'boom');
-}).add('EventEmitter 2', function test2() {
+}).add('EventEmitter2', function() {
   ee2.emit('foo');
   ee2.emit('foo', 'bar');
   ee2.emit('foo', 'bar', 'baz');
   ee2.emit('foo', 'bar', 'baz', 'boom');
-}).add('EventEmitter 3', function test2() {
+}).add('EventEmitter3@0.6.1', function() {
   ee3.emit('foo');
   ee3.emit('foo', 'bar');
   ee3.emit('foo', 'bar', 'baz');
   ee3.emit('foo', 'bar', 'baz', 'boom');
-}).add('EventEmitter 3 (master)', function test2() {
+}).add('EventEmitter3(master)', function() {
   master.emit('foo');
   master.emit('foo', 'bar');
   master.emit('foo', 'bar', 'baz');
   master.emit('foo', 'bar', 'baz', 'boom');
-}).add('Drip', function test2() {
+}).add('Drip', function() {
   drip.emit('foo');
   drip.emit('foo', 'bar');
   drip.emit('foo', 'bar', 'baz');
   drip.emit('foo', 'bar', 'baz', 'boom');
-}).add('fastemitter', function test2() {
+}).add('fastemitter', function() {
   fe.emit('foo');
   fe.emit('foo', 'bar');
   fe.emit('foo', 'bar', 'baz');
   fe.emit('foo', 'bar', 'baz', 'boom');
-}).add('event-emitter', function test2() {
+}).add('event-emitter', function() {
   ee.emit('foo');
   ee.emit('foo', 'bar');
   ee.emit('foo', 'bar', 'baz');
   ee.emit('foo', 'bar', 'baz', 'boom');
+}).add('contra.emitter', function() {
+  ce.emit('foo');
+  ce.emit('foo', 'bar');
+  ce.emit('foo', 'bar', 'baz');
+  ce.emit('foo', 'bar', 'baz', 'boom');
 }).on('cycle', function cycle(e) {
   var details = e.target;
 

--- a/benchmarks/template.js
+++ b/benchmarks/template.js
@@ -16,9 +16,9 @@ var logger = new(require('devnull'))({ timestamp: false, namespacing: 0 });
 
 (
   new benchmark.Suite()
-).add('<test1>', function test1() {
+).add('<test1>', function() {
 
-}).add('<test2>', function test2() {
+}).add('<test2>', function() {
 
 }).on('cycle', function cycle(e) {
   var details = e.target;


### PR DESCRIPTION
I initially updated the benchmark tests to compare a new event emitter, **contra.emitter**.  

However, I also updated benchmarks to compare **eventemitter3@0.6.1** to latest **eventemitter3@master**.  The results may surprise you.

See my comment regarding the preliminary results on running `emit.js` - https://github.com/goatslacker/alt/pull/231