### PR TITLE
Make use of the available alias.

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,10 +55,10 @@ EventEmitter.prototype.listeners = function listeners(event, exists) {
 
   if (exists) return !!available;
   if (!available) return [];
-  if (this._events[evt].fn) return [this._events[evt].fn];
+  if (available.fn) return [available.fn];
 
-  for (var i = 0, l = this._events[evt].length, ee = new Array(l); i < l; i++) {
-    ee[i] = this._events[evt][i].fn;
+  for (var i = 0, l = available.length, ee = new Array(l); i < l; i++) {
+    ee[i] = available[i].fn;
   }
 
   return ee;


### PR DESCRIPTION
This improves performance quite a bit by not having to do the same property lookup over and over. Also saves some bytes.