### PR TITLE
update benchmarks

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -2,21 +2,21 @@ Starting benchmark run/remove-emit.js
 
 ```
 log:      Finished benchmarking: "EventEmitter1"
-metric:   Count (80092), Cycles (8), Elapsed (5.647), Hz (1096819.8913914724)
+metric:   Count (300141), Cycles (7), Elapsed (5.485), Hz (5766727.97)
 log:      Finished benchmarking: "EventEmitter2"
-metric:   Count (88855), Cycles (5), Elapsed (5.485), Hz (1749209.7788571692)
+metric:   Count (239930), Cycles (9), Elapsed (5.533), Hz (4596532.2)
 log:      Finished benchmarking: "EventEmitter3@0.1.6"
-metric:   Count (111744), Cycles (5), Elapsed (5.47), Hz (2197651.5271676793)
+metric:   Count (245874), Cycles (8), Elapsed (5.531), Hz (4672592.64)
 log:      Finished benchmarking: "EventEmitter3(master)"
-metric:   Count (108822), Cycles (7), Elapsed (5.517), Hz (2131882.4282814)
+metric:   Count (246286), Cycles (7), Elapsed (5.496), Hz (4638523.64)
 log:      Finished benchmarking: "Drip"
-metric:   Count (143347), Cycles (5), Elapsed (5.451), Hz (2828855.1840182743)
+metric:   Count (357963), Cycles (7), Elapsed (5.497), Hz (6767097.99)
 log:      Finished benchmarking: "fastemitter"
 metric:   Count (0), Cycles (0), Elapsed (0), Hz (0)
 log:      Finished benchmarking: "event-emitter"
-metric:   Count (57843), Cycles (6), Elapsed (5.466), Hz (1144289.5359058087)
-log:      Finished benchmarking: "contra.emitter"
-metric:   Count (4770), Cycles (4), Elapsed (5.456), Hz (93702.399650408)
+metric:   Count (111401), Cycles (4), Elapsed (5.481), Hz (2112567.79)
+log:      Finished benchmarking: "contra/emitter"
+metric:   Count (5436), Cycles (5), Elapsed (5.422), Hz (103108.18)
 info:     Benchmark: "Drip" is the fastest.
 ```
 
@@ -24,21 +24,21 @@ Starting benchmark run/context.js
 
 ```
 log:      Finished benchmarking: "EventEmitter1"
-metric:   Count (37685), Cycles (7), Elapsed (5.658), Hz (532636.1073151424)
+metric:   Count (63780), Cycles (7), Elapsed (5.505), Hz (1218532.19)
 log:      Finished benchmarking: "EventEmitter2"
-metric:   Count (38578), Cycles (3), Elapsed (5.425), Hz (762300.4025491957)
+metric:   Count (60361), Cycles (6), Elapsed (5.442), Hz (1168465.4)
 log:      Finished benchmarking: "EventEmitter3@0.1.6"
-metric:   Count (175358), Cycles (5), Elapsed (5.451), Hz (3445044.0467826594)
+metric:   Count (641986), Cycles (6), Elapsed (5.402), Hz (12565337.33)
 log:      Finished benchmarking: "EventEmitter3(master)"
-metric:   Count (171660), Cycles (6), Elapsed (5.43), Hz (3371419.644849449)
+metric:   Count (610424), Cycles (7), Elapsed (5.483), Hz (11822617.33)
 log:      Finished benchmarking: "Drip"
-metric:   Count (44653), Cycles (7), Elapsed (5.532), Hz (877652.5928304944)
+metric:   Count (60685), Cycles (10), Elapsed (5.607), Hz (1168841.57)
 log:      Finished benchmarking: "fastemitter"
-metric:   Count (54033), Cycles (5), Elapsed (5.488), Hz (1066931.4618574267)
+metric:   Count (57613), Cycles (6), Elapsed (5.531), Hz (1121652.43)
 log:      Finished benchmarking: "event-emitter"
-metric:   Count (35121), Cycles (3), Elapsed (5.361), Hz (694423.8737320927)
-log:      Finished benchmarking: "contra.emitter"
-metric:   Count (3763), Cycles (5), Elapsed (5.404), Hz (73999.09635396695)
+metric:   Count (45978), Cycles (6), Elapsed (5.474), Hz (888976.81)
+log:      Finished benchmarking: "contra/emitter"
+metric:   Count (4512), Cycles (7), Elapsed (5.492), Hz (86561.56)
 info:     Benchmark: "EventEmitter3@0.1.6" is the fastest.
 ```
 
@@ -46,144 +46,144 @@ Starting benchmark run/emit.js
 
 ```
 log:      Finished benchmarking: "EventEmitter1"
-metric:   Count (103117), Cycles (5), Elapsed (5.477), Hz (1189957.286075274)
+metric:   Count (491710), Cycles (5), Elapsed (5.575), Hz (9350733.44)
 log:      Finished benchmarking: "EventEmitter2"
-metric:   Count (120168), Cycles (5), Elapsed (5.449), Hz (2362895.6234837566)
+metric:   Count (358006), Cycles (7), Elapsed (5.608), Hz (6917207.93)
 log:      Finished benchmarking: "EventEmitter3@0.1.6"
-metric:   Count (175669), Cycles (6), Elapsed (5.479), Hz (3440778.8106829566)
+metric:   Count (635957), Cycles (8), Elapsed (5.47), Hz (12174427.75)
 log:      Finished benchmarking: "EventEmitter3(master)"
-metric:   Count (170520), Cycles (6), Elapsed (5.571), Hz (3363994.072967049)
+metric:   Count (611044), Cycles (5), Elapsed (5.385), Hz (11467928.93)
 log:      Finished benchmarking: "Drip"
-metric:   Count (143307), Cycles (5), Elapsed (5.457), Hz (2828053.755592747)
+metric:   Count (354774), Cycles (8), Elapsed (5.488), Hz (6746871.4)
 log:      Finished benchmarking: "fastemitter"
-metric:   Count (243957), Cycles (6), Elapsed (5.508), Hz (4836112.669778523)
+metric:   Count (285710), Cycles (7), Elapsed (5.512), Hz (5401655.5)
 log:      Finished benchmarking: "event-emitter"
-metric:   Count (85612), Cycles (5), Elapsed (5.505), Hz (1687600.7705260126)
-log:      Finished benchmarking: "contra.emitter"
-metric:   Count (4765), Cycles (4), Elapsed (5.46), Hz (93370.89809584021)
-info:     Benchmark: "fastemitter" is the fastest.
+metric:   Count (135697), Cycles (4), Elapsed (5.438), Hz (2571125.67)
+log:      Finished benchmarking: "contra/emitter"
+metric:   Count (5513), Cycles (5), Elapsed (5.526), Hz (104834.15)
+info:     Benchmark: "EventEmitter3@0.1.6" is the fastest.
 ```
 
 Starting benchmark run/listeners.js
 
 ```
 log:      Finished benchmarking: "EventEmitter1"
-metric:   Count (269360), Cycles (8), Elapsed (5.632), Hz (5317029.372342782)
+metric:   Count (593534), Cycles (6), Elapsed (5.467), Hz (11496807.4)
 log:      Finished benchmarking: "fastemitter"
-metric:   Count (278301), Cycles (8), Elapsed (5.583), Hz (5503946.770137163)
+metric:   Count (335254), Cycles (4), Elapsed (5.489), Hz (6477042.13)
 log:      Finished benchmarking: "EventEmitter3@0.1.6"
-metric:   Count (124613), Cycles (5), Elapsed (5.538), Hz (2451663.5877780304)
+metric:   Count (263872), Cycles (4), Elapsed (5.533), Hz (5127778.92)
 log:      Finished benchmarking: "EventEmitter3(master)"
-metric:   Count (127075), Cycles (8), Elapsed (5.649), Hz (2507745.057769042)
-info:     Benchmark: "fastemitter" is the fastest.
+metric:   Count (531368), Cycles (4), Elapsed (5.375), Hz (10111356.8)
+info:     Benchmark: "EventEmitter1" is the fastest.
 ```
 
 Starting benchmark run/init.js
 
 ```
 log:      Finished benchmarking: "EventEmitter1"
-metric:   Count (1448843), Cycles (7), Elapsed (5.53), Hz (28614884.42105477)
+metric:   Count (2371903), Cycles (5), Elapsed (5.391), Hz (46101979.59)
 log:      Finished benchmarking: "EventEmitter2"
-metric:   Count (2021014), Cycles (8), Elapsed (5.562), Hz (39269318.213538975)
+metric:   Count (2762751), Cycles (4), Elapsed (5.321), Hz (52770261.7)
 log:      Finished benchmarking: "EventEmitter3@0.1.6"
-metric:   Count (4993728), Cycles (6), Elapsed (5.567), Hz (97916377.172198)
+metric:   Count (6391324), Cycles (4), Elapsed (5.304), Hz (125119847.85)
 log:      Finished benchmarking: "EventEmitter3(master)"
-metric:   Count (4882942), Cycles (5), Elapsed (5.399), Hz (95718450.95231998)
+metric:   Count (6385547), Cycles (4), Elapsed (5.305), Hz (122219853.56)
 log:      Finished benchmarking: "Drip"
-metric:   Count (4986681), Cycles (6), Elapsed (5.555), Hz (96640009.46844646)
+metric:   Count (6509454), Cycles (4), Elapsed (5.365), Hz (126618722.15)
 log:      Finished benchmarking: "fastemitter"
-metric:   Count (791603), Cycles (4), Elapsed (5.332), Hz (15336599.39739529)
+metric:   Count (955184), Cycles (7), Elapsed (5.609), Hz (18682885.18)
 log:      Finished benchmarking: "event-emitter"
-metric:   Count (11649), Cycles (4), Elapsed (5.386), Hz (229655.7906250341)
-log:      Finished benchmarking: "contra.emitter"
-metric:   Count (46646), Cycles (3), Elapsed (5.523), Hz (603381.7342078416)
-info:     Benchmark: "EventEmitter3@0.1.6" is the fastest.
+metric:   Count (12248), Cycles (4), Elapsed (5.466), Hz (237939.18)
+log:      Finished benchmarking: "contra/emitter"
+metric:   Count (91125), Cycles (3), Elapsed (5.458), Hz (1466162.84)
+info:     Benchmark: "Drip" is the fastest.
 ```
 
 Starting benchmark run/once.js
 
 ```
 log:      Finished benchmarking: "EventEmitter1"
-metric:   Count (43422), Cycles (5), Elapsed (5.45), Hz (855313.2869111028)
+metric:   Count (244173), Cycles (6), Elapsed (5.598), Hz (4646107.77)
 log:      Finished benchmarking: "EventEmitter2"
-metric:   Count (26634), Cycles (6), Elapsed (5.455), Hz (520416.6222005621)
+metric:   Count (74973), Cycles (7), Elapsed (5.467), Hz (1406731.22)
 log:      Finished benchmarking: "EventEmitter3@0.1.6"
-metric:   Count (59702), Cycles (5), Elapsed (5.402), Hz (1166270.1245115455)
+metric:   Count (121604), Cycles (7), Elapsed (5.77), Hz (2294819.86)
 log:      Finished benchmarking: "EventEmitter3(master)"
-metric:   Count (61460), Cycles (6), Elapsed (5.588), Hz (1200318.797352782)
+metric:   Count (111839), Cycles (5), Elapsed (5.343), Hz (2072445.8)
 log:      Finished benchmarking: "Drip"
-metric:   Count (100574), Cycles (5), Elapsed (5.652), Hz (1977052.3371757295)
+metric:   Count (362602), Cycles (5), Elapsed (5.417), Hz (6743602.42)
 log:      Finished benchmarking: "fastemitter"
-metric:   Count (283438), Cycles (7), Elapsed (5.545), Hz (5610265.401583704)
+metric:   Count (295873), Cycles (5), Elapsed (5.442), Hz (5711255.82)
 log:      Finished benchmarking: "event-emitter"
-metric:   Count (51190), Cycles (5), Elapsed (5.521), Hz (1004278.1853791866)
-log:      Finished benchmarking: "contra.emitter"
-metric:   Count (14136), Cycles (5), Elapsed (5.52), Hz (277413.74059963966)
-info:     Benchmark: "fastemitter" is the fastest.
+metric:   Count (67064), Cycles (5), Elapsed (5.447), Hz (1266180.56)
+log:      Finished benchmarking: "contra/emitter"
+metric:   Count (23296), Cycles (5), Elapsed (5.574), Hz (436957.6)
+info:     Benchmark: "Drip" is the fastest.
 ```
 
 Starting benchmark run/multiple-emitters.js
 
 ```
 log:      Finished benchmarking: "EventEmitter1"
-metric:   Count (24773), Cycles (5), Elapsed (5.471), Hz (448903.57892067777)
+metric:   Count (182871), Cycles (5), Elapsed (5.452), Hz (3557110.76)
 log:      Finished benchmarking: "EventEmitter2"
-metric:   Count (24978), Cycles (5), Elapsed (5.437), Hz (492689.62686539674)
+metric:   Count (45337), Cycles (7), Elapsed (5.512), Hz (877344.25)
 log:      Finished benchmarking: "EventEmitter3@0.1.6"
-metric:   Count (61060), Cycles (8), Elapsed (5.57), Hz (1198579.6057034628)
+metric:   Count (143759), Cycles (4), Elapsed (5.389), Hz (2771580.78)
 log:      Finished benchmarking: "EventEmitter3(master)"
-metric:   Count (60832), Cycles (7), Elapsed (5.645), Hz (1190559.465872349)
+metric:   Count (145497), Cycles (5), Elapsed (5.491), Hz (2780475.14)
 log:      Finished benchmarking: "Drip"
 metric:   Count (0), Cycles (0), Elapsed (0), Hz (0)
 log:      Finished benchmarking: "fastemitter"
-metric:   Count (114392), Cycles (5), Elapsed (5.432), Hz (2259351.1150187775)
+metric:   Count (140028), Cycles (7), Elapsed (5.626), Hz (2664390.63)
 log:      Finished benchmarking: "event-emitter"
-metric:   Count (20270), Cycles (5), Elapsed (5.518), Hz (401411.35445897694)
-log:      Finished benchmarking: "contra.emitter"
-metric:   Count (4225), Cycles (4), Elapsed (5.372), Hz (81828.58841880377)
-info:     Benchmark: "fastemitter" is the fastest.
+metric:   Count (35605), Cycles (5), Elapsed (5.519), Hz (685442.78)
+log:      Finished benchmarking: "contra/emitter"
+metric:   Count (4989), Cycles (5), Elapsed (5.447), Hz (93632.37)
+info:     Benchmark: "EventEmitter1" is the fastest.
 ```
 
 Starting benchmark run/hundreds.js
 
 ```
 log:      Finished benchmarking: "EventEmitter1"
-metric:   Count (9580), Cycles (4), Elapsed (5.486), Hz (188745.0026768704)
+metric:   Count (20350), Cycles (6), Elapsed (5.489), Hz (387624.02)
 log:      Finished benchmarking: "EventEmitter2"
-metric:   Count (8929), Cycles (4), Elapsed (5.396), Hz (176205.64423712614)
+metric:   Count (8866), Cycles (3), Elapsed (5.355), Hz (170348.45)
 log:      Finished benchmarking: "EventEmitter3@0.1.6"
-metric:   Count (18746), Cycles (4), Elapsed (5.442), Hz (363743.4361172706)
+metric:   Count (18433), Cycles (5), Elapsed (5.448), Hz (358090.16)
 log:      Finished benchmarking: "EventEmitter3(master)"
-metric:   Count (18997), Cycles (6), Elapsed (5.471), Hz (361006.2257442707)
+metric:   Count (18120), Cycles (7), Elapsed (5.521), Hz (352318.05)
 log:      Finished benchmarking: "Drip"
-metric:   Count (23491), Cycles (4), Elapsed (5.378), Hz (455803.14878908196)
+metric:   Count (24497), Cycles (7), Elapsed (5.524), Hz (473331.47)
 log:      Finished benchmarking: "fastemitter"
-metric:   Count (19093), Cycles (6), Elapsed (5.507), Hz (378275.92507385544)
+metric:   Count (24421), Cycles (5), Elapsed (5.457), Hz (472979.48)
 log:      Finished benchmarking: "event-emitter"
-metric:   Count (6973), Cycles (6), Elapsed (5.48), Hz (137006.51784960757)
-log:      Finished benchmarking: "contra.emitter"
-metric:   Count (1384), Cycles (5), Elapsed (5.51), Hz (27039.085903693027)
-info:     Benchmark: "Drip" is the fastest.
+metric:   Count (8095), Cycles (5), Elapsed (5.604), Hz (157427.97)
+log:      Finished benchmarking: "contra/emitter"
+metric:   Count (2151), Cycles (7), Elapsed (5.636), Hz (41010.9)
+info:     Benchmark: "Drip,fastemitter" is the fastest.
 ```
 
 Starting benchmark run/listening.js
 
 ```
 log:      Finished benchmarking: "EventEmitter1"
-metric:   Count (79539), Cycles (5), Elapsed (5.474), Hz (1561366.087289596)
+metric:   Count (587805), Cycles (7), Elapsed (5.571), Hz (11305119.11)
 log:      Finished benchmarking: "EventEmitter2"
-metric:   Count (50617), Cycles (3), Elapsed (5.478), Hz (971253.3687066672)
+metric:   Count (108192), Cycles (6), Elapsed (5.555), Hz (2086559.09)
 log:      Finished benchmarking: "EventEmitter3@0.1.6"
-metric:   Count (75810), Cycles (8), Elapsed (5.546), Hz (1494051.2716477334)
+metric:   Count (136498), Cycles (7), Elapsed (5.487), Hz (2603701.52)
 log:      Finished benchmarking: "EventEmitter3(master)"
-metric:   Count (83171), Cycles (5), Elapsed (5.599), Hz (1619007.7247514057)
+metric:   Count (123469), Cycles (6), Elapsed (5.564), Hz (2368749.83)
 log:      Finished benchmarking: "Drip"
-metric:   Count (171316), Cycles (7), Elapsed (5.509), Hz (3358071.9545307877)
+metric:   Count (1582232), Cycles (7), Elapsed (5.517), Hz (30514861.04)
 log:      Finished benchmarking: "fastemitter"
-metric:   Count (849965), Cycles (5), Elapsed (5.451), Hz (16683655.91602093)
+metric:   Count (952524), Cycles (5), Elapsed (5.575), Hz (18337197.08)
 log:      Finished benchmarking: "event-emitter"
-metric:   Count (67243), Cycles (5), Elapsed (5.439), Hz (1318150.6044139024)
-log:      Finished benchmarking: "contra.emitter"
-metric:   Count (159097), Cycles (5), Elapsed (5.488), Hz (3123523.636676117)
-info:     Benchmark: "fastemitter" is the fastest.
+metric:   Count (103718), Cycles (4), Elapsed (5.414), Hz (2011935.8)
+log:      Finished benchmarking: "contra/emitter"
+metric:   Count (356517), Cycles (4), Elapsed (5.387), Hz (6918922.38)
+info:     Benchmark: "Drip" is the fastest.
 ```

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -11,11 +11,11 @@
   "dependencies": {
     "benchmark": "1.0.x",
     "devnull": "0.0.12",
-    "drip": "*",
-    "event-emitter": "*",
-    "eventemitter2": "*",
+    "drip": "latest",
+    "event-emitter": "latest",
+    "eventemitter2": "latest",
     "eventemitter3": "0.1.6",
-    "fastemitter": "*",
-    "contra.emitter": "*"
+    "fastemitter": "latest",
+    "contra": "latest"
   }
 }

--- a/benchmarks/run/context.js
+++ b/benchmarks/run/context.js
@@ -20,7 +20,7 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
   , Drip = require('drip').EventEmitter
   , EE = require('event-emitter')
   , FE = require('fastemitter')
-  , CE = require('contra.emitter');
+  , CE = require('contra/emitter');
 
 function handle() {
   if (arguments.length > 100) console.log('damn');
@@ -84,7 +84,7 @@ ce.on('foo', handle.bind(logger));
   ee.emit('foo', 'bar');
   ee.emit('foo', 'bar', 'baz');
   ee.emit('foo', 'bar', 'baz', 'boom');
-}).add('contra.emitter', function() {
+}).add('contra/emitter', function() {
   ce.emit('foo');
   ce.emit('foo', 'bar');
   ce.emit('foo', 'bar', 'baz');
@@ -97,7 +97,7 @@ ce.on('foo', handle.bind(logger));
     , details.count
     , details.cycles
     , details.times.elapsed
-    , details.hz
+    , details.hz.toFixed(2)
   );
 }).on('complete', function completed() {
   logger.info('Benchmark: "%s" is the fastest.'

--- a/benchmarks/run/emit.js
+++ b/benchmarks/run/emit.js
@@ -20,7 +20,7 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
   , Drip = require('drip').EventEmitter
   , EE = require('event-emitter')
   , FE = require('fastemitter')
-  , CE = require('contra.emitter');
+  , CE = require('contra/emitter');
 
 function handle() {
   if (arguments.length > 100) console.log('damn');
@@ -84,7 +84,7 @@ ce.on('foo', handle);
   ee.emit('foo', 'bar');
   ee.emit('foo', 'bar', 'baz');
   ee.emit('foo', 'bar', 'baz', 'boom');
-}).add('contra.emitter', function() {
+}).add('contra/emitter', function() {
   ce.emit('foo');
   ce.emit('foo', 'bar');
   ce.emit('foo', 'bar', 'baz');
@@ -97,7 +97,7 @@ ce.on('foo', handle);
     , details.count
     , details.cycles
     , details.times.elapsed
-    , details.hz
+    , details.hz.toFixed(2)
   );
 }).on('complete', function completed() {
   logger.info('Benchmark: "%s" is the fastest.'

--- a/benchmarks/run/hundreds.js
+++ b/benchmarks/run/hundreds.js
@@ -20,7 +20,7 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
   , Drip = require('drip').EventEmitter
   , EE = require('event-emitter')
   , FE = require('fastemitter')
-  , CE = require('contra.emitter');
+  , CE = require('contra/emitter');
 
 function foo() {
   if (arguments.length > 100) console.log('damn');
@@ -84,7 +84,7 @@ for (i = 0; i < 10; i++) {
   for (i = 0; i < 10; i++) {
     ee.emit('event:' + i);
   }
-}).add('contra.emitter', function() {
+}).add('contra/emitter', function() {
   for (i = 0; i < 10; i++) {
     ce.emit('event:' + i);
   }
@@ -96,7 +96,7 @@ for (i = 0; i < 10; i++) {
     , details.count
     , details.cycles
     , details.times.elapsed
-    , details.hz
+    , details.hz.toFixed(2)
   );
 }).on('complete', function completed() {
   logger.info('Benchmark: "%s" is the fastest.'

--- a/benchmarks/run/init.js
+++ b/benchmarks/run/init.js
@@ -20,7 +20,7 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
   , Drip = require('drip').EventEmitter
   , EE = require('event-emitter')
   , FE = require('fastemitter')
-  , CE = require('contra.emitter');
+  , CE = require('contra/emitter');
 
 
 (
@@ -39,7 +39,7 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
   var fe = new FE();
 }).add('event-emitter', function() {
   var ee = EE({});
-}).add('contra.emitter', function() {
+}).add('contra/emitter', function() {
   var ce = CE();
 }).on('cycle', function cycle(e) {
   var details = e.target;
@@ -49,7 +49,7 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
     , details.count
     , details.cycles
     , details.times.elapsed
-    , details.hz
+    , details.hz.toFixed(2)
   );
 }).on('complete', function completed() {
   logger.info('Benchmark: "%s" is the fastest.'

--- a/benchmarks/run/listeners.js
+++ b/benchmarks/run/listeners.js
@@ -47,7 +47,7 @@ for (var i = 0; i < 25; i++) {
 // EE2 doesn't correctly handle listeners as they can be removed by doing a
 // ee2.listeners('event').length = 0; kills the event emitter, same counts for
 // Drip.
-// event-emitter and contra.emitter does not implement.
+// event-emitter and contra/emitter does not implement.
 //
 
 (
@@ -68,7 +68,7 @@ for (var i = 0; i < 25; i++) {
     , details.count
     , details.cycles
     , details.times.elapsed
-    , details.hz
+    , details.hz.toFixed(2)
   );
 }).on('complete', function completed() {
   logger.info('Benchmark: "%s" is the fastest.'

--- a/benchmarks/run/listening.js
+++ b/benchmarks/run/listening.js
@@ -20,7 +20,7 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
   , Drip = require('drip').EventEmitter
   , EE = require('event-emitter')
   , FE = require('fastemitter')
-  , CE = require('contra.emitter');
+  , CE = require('contra/emitter');
 
 function handle() {
   if (arguments.length > 100) console.log('damn');
@@ -61,7 +61,7 @@ var ee2 = new EventEmitter2()
 }).add('event-emitter', function() {
   ee.on('foo', handle);
   ee.off('foo', handle);
-}).add('contra.emitter', function() {
+}).add('contra/emitter', function() {
   ce.on('foo', handle);
   ce.off('foo', handle);
 }).on('cycle', function cycle(e) {
@@ -72,7 +72,7 @@ var ee2 = new EventEmitter2()
     , details.count
     , details.cycles
     , details.times.elapsed
-    , details.hz
+    , details.hz.toFixed(2)
   );
 }).on('complete', function completed() {
   logger.info('Benchmark: "%s" is the fastest.'

--- a/benchmarks/run/multiple-emitters.js
+++ b/benchmarks/run/multiple-emitters.js
@@ -20,7 +20,7 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
   , Drip = require('drip').EventEmitter
   , EE = require('event-emitter')
   , FE = require('fastemitter')
-  , CE = require('contra.emitter');
+  , CE = require('contra/emitter');
 
 
 function foo() {
@@ -99,7 +99,7 @@ master.on('foo', foo).on('foo', bar).on('foo', baz);
   ee.emit('foo', 'bar');
   ee.emit('foo', 'bar', 'baz');
   ee.emit('foo', 'bar', 'baz', 'boom');
-}).add('contra.emitter', function() {
+}).add('contra/emitter', function() {
   ce.emit('foo');
   ce.emit('foo', 'bar');
   ce.emit('foo', 'bar', 'baz');
@@ -112,7 +112,7 @@ master.on('foo', foo).on('foo', bar).on('foo', baz);
     , details.count
     , details.cycles
     , details.times.elapsed
-    , details.hz
+    , details.hz.toFixed(2)
   );
 }).on('complete', function completed() {
   logger.info('Benchmark: "%s" is the fastest.'

--- a/benchmarks/run/once.js
+++ b/benchmarks/run/once.js
@@ -20,7 +20,7 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
   , Drip = require('drip').EventEmitter
   , EE = require('event-emitter')
   , FE = require('fastemitter')
-  , CE = require('contra.emitter');
+  , CE = require('contra/emitter');
 
 function handle() {
   if (arguments.length > 100) console.log('damn');
@@ -54,7 +54,7 @@ var ee2 = new EventEmitter2()
   fe.once('foo', handle).emit('foo');
 }).add('event-emitter', function() {
   ee.once('foo', handle).emit('foo');
-}).add('contra.emitter', function() {
+}).add('contra/emitter', function() {
   ce.once('foo', handle).emit('foo');
 }).on('cycle', function cycle(e) {
   var details = e.target;
@@ -64,7 +64,7 @@ var ee2 = new EventEmitter2()
     , details.count
     , details.cycles
     , details.times.elapsed
-    , details.hz
+    , details.hz.toFixed(2)
   );
 }).on('complete', function completed() {
   logger.info('Benchmark: "%s" is the fastest.'

--- a/benchmarks/run/remove-emit.js
+++ b/benchmarks/run/remove-emit.js
@@ -20,7 +20,7 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
   , Drip = require('drip').EventEmitter
   , EE = require('event-emitter')
   , FE = require('fastemitter')
-  , CE = require('contra.emitter');
+  , CE = require('contra/emitter');
 
 
 function handle() {
@@ -89,7 +89,7 @@ var ee2 = new EventEmitter2()
   ee.emit('foo', 'bar');
   ee.emit('foo', 'bar', 'baz');
   ee.emit('foo', 'bar', 'baz', 'boom');
-}).add('contra.emitter', function() {
+}).add('contra/emitter', function() {
   ce.emit('foo');
   ce.emit('foo', 'bar');
   ce.emit('foo', 'bar', 'baz');
@@ -102,7 +102,7 @@ var ee2 = new EventEmitter2()
     , details.count
     , details.cycles
     , details.times.elapsed
-    , details.hz
+    , details.hz.toFixed(2)
   );
 }).on('complete', function completed() {
   logger.info('Benchmark: "%s" is the fastest.'

--- a/benchmarks/template.js
+++ b/benchmarks/template.js
@@ -28,7 +28,7 @@ var logger = new(require('devnull'))({ timestamp: false, namespacing: 0 });
     , details.count
     , details.cycles
     , details.times.elapsed
-    , details.hz
+    , details.hz.toFixed(2)
   );
 }).on('complete', function completed() {
   logger.info('Benchmark: "%s" is the fastest.'


### PR DESCRIPTION
 - contra.emitter -> contra/emitter
 - use npm tag 'latest' (`*` won't work with fastemitter see npm/npm#8711)
 - truncate Hz value to 2 decimal points