### PR TITLE
Copy listeners before emitting an event

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ EventEmitter.prototype.emit = function emit(event, a1, a2, a3, a4, a5) {
 
   if (!this._events || !this._events[evt]) return false;
 
-  var listeners = this._events[evt]
+  var listeners = this._events[evt].slice()
     , len = arguments.length
     , args
     , i;


### PR DESCRIPTION
This fix aims to solve an issue that could arise should listeners be added/removed inside an event callback.

It has some perf issues, but I fear that it cannot be helped. What do you think?