### PR TITLE
Add `eventNames` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var has = Object.prototype.hasOwnProperty;
+
 //
 // We store our EE objects in a plain object whose properties are event names.
 // If `Object.create(null)` is not supported we prefix the event names with a
@@ -34,12 +36,37 @@ function EE(fn, context, once) {
 function EventEmitter() { /* Nothing to set */ }
 
 /**
- * Holds the assigned EventEmitters by name.
+ * Hold the assigned EventEmitters by name.
  *
  * @type {Object}
  * @private
  */
 EventEmitter.prototype._events = undefined;
+
+/**
+ * Return an array listing the events for which the emitter has registered
+ * listeners.
+ *
+ * @returns {Array}
+ * @api public
+ */
+EventEmitter.prototype.eventNames = function eventNames() {
+  var events = this._events
+    , names = []
+    , name;
+
+  if (!events) return names;
+
+  for (name in events) {
+    if (has.call(events, name)) names.push(prefix ? name.slice(1) : name);
+  }
+
+  if (Object.getOwnPropertySymbols) {
+    return names.concat(Object.getOwnPropertySymbols(events));
+  }
+
+  return names;
+};
 
 /**
  * Return a list of assigned event listeners.

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
   "devDependencies": {
     "assume": "1.3.x",
     "istanbul": "0.4.x",
-    "mocha": "2.3.x",
+    "mocha": "2.4.x",
     "pre-commit": "1.1.x",
-    "zuul": "3.9.x"
+    "zuul": "3.10.x"
   }
 }

--- a/test.js
+++ b/test.js
@@ -96,7 +96,7 @@ describe('EventEmitter', function tests() {
     it('can emit the function with multiple arguments', function () {
       var e = new EventEmitter();
 
-      for(var i = 0; i < 100; i++) {
+      for (var i = 0; i < 100; i++) {
         (function (j) {
           for (var i = 0, args = []; i < j; i++) {
             args.push(j);
@@ -253,14 +253,14 @@ describe('EventEmitter', function tests() {
     });
 
     it('returns an array of function', function () {
-       var e = new EventEmitter();
+      var e = new EventEmitter();
 
-       function foo() {}
+      function foo() {}
 
-       e.on('foo', foo);
-       assume(e.listeners('foo')).is.a('array');
-       assume(e.listeners('foo').length).equals(1);
-       assume(e.listeners('foo')).deep.equals([foo]);
+      e.on('foo', foo);
+      assume(e.listeners('foo')).is.a('array');
+      assume(e.listeners('foo').length).equals(1);
+      assume(e.listeners('foo')).deep.equals([foo]);
     });
 
     it('is not vulnerable to modifications', function () {
@@ -502,7 +502,67 @@ describe('EventEmitter', function tests() {
     });
   });
 
-  describe('#setMaxListeners', function () {
+  describe('EventEmitter#eventNames', function () {
+    it('returns an empty array when there are no events', function () {
+      var e = new EventEmitter();
+
+      assume(e.eventNames()).eql([]);
+
+      e.on('foo', function () {});
+      e.removeAllListeners('foo');
+
+      assume(e.eventNames()).eql([]);
+    });
+
+    it('returns an array listing the events that have listeners', function () {
+      var e = new EventEmitter();
+
+      function bar() {}
+
+      e.on('foo', function () {});
+      e.on('bar', bar);
+
+      assume(e.eventNames()).eql(['foo', 'bar']);
+
+      e.removeListener('bar', bar);
+
+      assume(e.eventNames()).eql(['foo']);
+    });
+
+    it('does not return inherited properties', function () {
+      var e = new EventEmitter();
+
+      function Dummy() {}
+      function Collection() {}
+
+      Dummy.prototype.foo = 'foo';
+      Collection.prototype = new Dummy();
+      Collection.prototype.constructor = Collection;
+
+      e._events = new Collection();
+
+      assume(e._events.foo).equal('foo');
+      assume(e.eventNames()).eql([]);
+    });
+
+    if ('undefined' !== typeof Symbol) it('includes ES6 symbols', function () {
+      var e = new EventEmitter()
+        , s = Symbol('s');
+
+      function foo() {}
+
+      e.on('foo', foo);
+      e.on(s, function () {});
+
+      assume(e.eventNames()).eql(['foo', s]);
+
+      e.removeListener('foo', foo);
+
+      assume(e.eventNames()).eql([s]);
+    });
+  });
+
+  describe('EventEmitter#setMaxListeners', function () {
     it('is a function', function () {
       var e = new EventEmitter();
 


### PR DESCRIPTION
This adds a new method called `eventNames` that returns an array listing the events for which the emitter has registered listeners.

The same [method](https://github.com/nodejs/node/pull/5617/files) has been added in the EventEmitter that ships with node.

It will also helps us with https://github.com/unshiftio/ultron/issues/6.