### PR TITLE
Set the _events property at instantiation time

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,33 @@
 'use strict';
 
-var has = Object.prototype.hasOwnProperty;
+var has = Object.prototype.hasOwnProperty
+  , prefix = '~';
+
+/**
+ * This constructor is used to create a storage for our EE objects.
+ * An `Events` instance is a plain object whose properties are event names.
+ *
+ * @constructor
+ * @api private
+ */
+function Events() {}
 
 //
-// We store our EE objects in a plain object whose properties are event names.
+// We try to not inherit from `Object.prototype`. In some engines creating an
+// instance in this way is faster than calling `Object.create(null)` directly.
 // If `Object.create(null)` is not supported we prefix the event names with a
-// `~` to make sure that the built-in object properties are not overridden or
-// used as an attack vector.
-// We also assume that `Object.create(null)` is available when the event name
-// is an ES6 Symbol.
+// character to make sure that the built-in object properties are not
+// overridden or used as an attack vector.
 //
-var prefix = typeof Object.create !== 'function' ? '~' : false;
+if (Object.create) {
+  Events.prototype = Object.create(null);
+
+  //
+  // This hack is needed because the `__proto__` property is still inherited in
+  // some old browsers like Android 4, iPhone 5.1, Opera 11 and Safari 5.
+  //
+  if (!new Events().__proto__) prefix = false;
+}
 
 /**
  * Representation of a single EventEmitter function.
@@ -18,6 +35,7 @@ var prefix = typeof Object.create !== 'function' ? '~' : false;
  * @param {Function} fn Event handler to be called.
  * @param {Mixed} context Context for function execution.
  * @param {Boolean} [once=false] Only emit once
+ * @constructor
  * @api private
  */
 function EE(fn, context, once) {
@@ -34,7 +52,7 @@ function EE(fn, context, once) {
  * @api public
  */
 function EventEmitter() {
-  this._events = prefix ? {} : Object.create(null);
+  this._events = new Events();
 }
 
 /**
@@ -245,7 +263,7 @@ EventEmitter.prototype.removeListener = function removeListener(event, fn, conte
  */
 EventEmitter.prototype.removeAllListeners = function removeAllListeners(event) {
   if (event) delete this._events[prefix ? prefix + event : event];
-  else this._events = prefix ? {} : Object.create(null);
+  else this._events = new Events();
 
   return this;
 };

--- a/index.js
+++ b/index.js
@@ -33,15 +33,9 @@ function EE(fn, context, once) {
  * @constructor
  * @api public
  */
-function EventEmitter() { /* Nothing to set */ }
-
-/**
- * Hold the assigned EventEmitters by name.
- *
- * @type {Object}
- * @private
- */
-EventEmitter.prototype._events = undefined;
+function EventEmitter() {
+  this._events = prefix ? {} : Object.create(null);
+}
 
 /**
  * Return an array listing the events for which the emitter has registered
@@ -54,8 +48,6 @@ EventEmitter.prototype.eventNames = function eventNames() {
   var events = this._events
     , names = []
     , name;
-
-  if (!events) return names;
 
   for (name in events) {
     if (has.call(events, name)) names.push(prefix ? name.slice(1) : name);
@@ -78,7 +70,7 @@ EventEmitter.prototype.eventNames = function eventNames() {
  */
 EventEmitter.prototype.listeners = function listeners(event, exists) {
   var evt = prefix ? prefix + event : event
-    , available = this._events && this._events[evt];
+    , available = this._events[evt];
 
   if (exists) return !!available;
   if (!available) return [];
@@ -101,7 +93,7 @@ EventEmitter.prototype.listeners = function listeners(event, exists) {
 EventEmitter.prototype.emit = function emit(event, a1, a2, a3, a4, a5) {
   var evt = prefix ? prefix + event : event;
 
-  if (!this._events || !this._events[evt]) return false;
+  if (!this._events[evt]) return false;
 
   var listeners = this._events[evt]
     , len = arguments.length
@@ -162,7 +154,6 @@ EventEmitter.prototype.on = function on(event, fn, context) {
   var listener = new EE(fn, context || this)
     , evt = prefix ? prefix + event : event;
 
-  if (!this._events) this._events = prefix ? {} : Object.create(null);
   if (!this._events[evt]) this._events[evt] = listener;
   else {
     if (!this._events[evt].fn) this._events[evt].push(listener);
@@ -186,7 +177,6 @@ EventEmitter.prototype.once = function once(event, fn, context) {
   var listener = new EE(fn, context || this, true)
     , evt = prefix ? prefix + event : event;
 
-  if (!this._events) this._events = prefix ? {} : Object.create(null);
   if (!this._events[evt]) this._events[evt] = listener;
   else {
     if (!this._events[evt].fn) this._events[evt].push(listener);
@@ -210,7 +200,7 @@ EventEmitter.prototype.once = function once(event, fn, context) {
 EventEmitter.prototype.removeListener = function removeListener(event, fn, context, once) {
   var evt = prefix ? prefix + event : event;
 
-  if (!this._events || !this._events[evt]) return this;
+  if (!this._events[evt]) return this;
   if (!fn) return delete this._events[evt], this;
 
   var listeners = this._events[evt];
@@ -254,8 +244,6 @@ EventEmitter.prototype.removeListener = function removeListener(event, fn, conte
  * @api public
  */
 EventEmitter.prototype.removeAllListeners = function removeAllListeners(event) {
-  if (!this._events) return this;
-
   if (event) delete this._events[prefix ? prefix + event : event];
   else this._events = prefix ? {} : Object.create(null);
 

--- a/test.js
+++ b/test.js
@@ -11,7 +11,7 @@ describe('EventEmitter', function tests() {
 
   it('inherits when used with require(util).inherits', function () {
     function Beast() {
-      /* rawr, i'm a beast */
+      EventEmitter.call(this);
     }
 
     require('util').inherits(Beast, EventEmitter);


### PR DESCRIPTION
With this patch the `_events` property will be set at instantiation time.

**Advantages**:

- Slightly improved perfomances (We don't have to check if `_events` is there every time)
- Smaller size

**Disadvantages:**

- Breaking change (see below)
- Slower initialization

**This is a breaking change because it affects inheritance. The child class must call the super constructor:**

```js
const EventEmitter = require('eventemitter3');
const util = require('util');

function Foo() {
  EventEmitter.call(this);
}

util.inherits(Foo, EventEmitter);
```

The speed-up is not jaw dropping but still significant, here are the results of the benchmarks:

```
Starting benchmark context.js

 log:      Finished benchmarking: "EventEmitter3@1.2.0"
 metric:   Count (299191), Cycles (6), Elapsed (5.604), Hz (5613026.04)
 log:      Finished benchmarking: "EventEmitter3(master)"
 metric:   Count (312118), Cycles (6), Elapsed (5.482), Hz (5901023.66)
 info:     Benchmark: "EventEmitter3(master)" is the fastest.

Starting benchmark emit.js

 log:      Finished benchmarking: "EventEmitter3@1.2.0"
 metric:   Count (308823), Cycles (6), Elapsed (5.617), Hz (5823376.75)
 log:      Finished benchmarking: "EventEmitter3(master)"
 metric:   Count (317839), Cycles (6), Elapsed (5.611), Hz (5998590)
 info:     Benchmark: "EventEmitter3(master)" is the fastest.

Starting benchmark hundreds.js

 log:      Finished benchmarking: "EventEmitter3@1.2.0"
 metric:   Count (10156), Cycles (4), Elapsed (5.498), Hz (195014.76)
 log:      Finished benchmarking: "EventEmitter3(master)"
 metric:   Count (10225), Cycles (6), Elapsed (5.565), Hz (192789.82)
 info:     Benchmark: "EventEmitter3@1.2.0,EventEmitter3(master)" is the fastest.

Starting benchmark init.js

 log:      Finished benchmarking: "EventEmitter3@1.2.0"
 metric:   Count (3490857), Cycles (4), Elapsed (5.542), Hz (62562484.87)
 log:      Finished benchmarking: "EventEmitter3(master)"
 metric:   Count (297871), Cycles (6), Elapsed (5.682), Hz (5758290.37)
 info:     Benchmark: "EventEmitter3@1.2.0" is the fastest.

Starting benchmark listeners.js

 log:      Finished benchmarking: "EventEmitter3@1.2.0"
 metric:   Count (263887), Cycles (4), Elapsed (5.643), Hz (5139874.56)
 log:      Finished benchmarking: "EventEmitter3(master)"
 metric:   Count (263150), Cycles (6), Elapsed (5.568), Hz (5067597.17)
 info:     Benchmark: "EventEmitter3@1.2.0" is the fastest.

Starting benchmark listening.js

 log:      Finished benchmarking: "EventEmitter3@1.2.0"
 metric:   Count (62220), Cycles (5), Elapsed (5.752), Hz (1195215.57)
 log:      Finished benchmarking: "EventEmitter3(master)"
 metric:   Count (65124), Cycles (6), Elapsed (5.7), Hz (1248543.72)
 info:     Benchmark: "EventEmitter3(master)" is the fastest.

Starting benchmark multiple-emitters.js

 log:      Finished benchmarking: "EventEmitter3@1.2.0"
 metric:   Count (69951), Cycles (5), Elapsed (5.64), Hz (1241496.62)
 log:      Finished benchmarking: "EventEmitter3(master)"
 metric:   Count (74193), Cycles (5), Elapsed (5.607), Hz (1429377.6)
 info:     Benchmark: "EventEmitter3(master)" is the fastest.

Starting benchmark once.js

 log:      Finished benchmarking: "EventEmitter3@1.2.0"
 metric:   Count (53357), Cycles (4), Elapsed (5.503), Hz (998778.29)
 log:      Finished benchmarking: "EventEmitter3(master)"
 metric:   Count (56454), Cycles (7), Elapsed (5.616), Hz (1056860.99)
 info:     Benchmark: "EventEmitter3(master)" is the fastest.

Starting benchmark remove-emit.js

 log:      Finished benchmarking: "EventEmitter3@1.2.0"
 metric:   Count (87439), Cycles (6), Elapsed (5.69), Hz (1688924.19)
 log:      Finished benchmarking: "EventEmitter3(master)"
 metric:   Count (90500), Cycles (6), Elapsed (5.509), Hz (1746345.1)
 info:     Benchmark: "EventEmitter3(master)" is the fastest.
```