### PR TITLE
Include only the enumerable symbol properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var has = Object.prototype.hasOwnProperty;
+var enumerable = Object.prototype.propertyIsEnumerable
+  , has = Object.prototype.hasOwnProperty;
 
 //
 // We store our EE objects in a plain object whose properties are event names.
@@ -62,7 +63,11 @@ EventEmitter.prototype.eventNames = function eventNames() {
   }
 
   if (Object.getOwnPropertySymbols) {
-    return names.concat(Object.getOwnPropertySymbols(events));
+    var symbols = Object.getOwnPropertySymbols(events);
+
+    for (var i = 0, l = symbols.length; i < l; i++) {
+      if (enumerable.call(events, symbols[i])) names.push(symbols[i]);
+    }
   }
 
   return names;

--- a/test.js
+++ b/test.js
@@ -529,7 +529,7 @@ describe('EventEmitter', function tests() {
       assume(e.eventNames()).eql(['foo']);
     });
 
-    it('does not return inherited properties', function () {
+    it('does not return inherited property identifiers', function () {
       var e = new EventEmitter();
 
       function Dummy() {}
@@ -547,18 +547,21 @@ describe('EventEmitter', function tests() {
 
     if ('undefined' !== typeof Symbol) it('includes ES6 symbols', function () {
       var e = new EventEmitter()
-        , s = Symbol('s');
+        , sym1 = Symbol()
+        , sym2 = Symbol();
 
       function foo() {}
 
       e.on('foo', foo);
-      e.on(s, function () {});
+      e.on(sym1, function () {});
 
-      assume(e.eventNames()).eql(['foo', s]);
+      Object.defineProperty(e._events, sym2, { value: 'bar' });
+
+      assume(e.eventNames()).eql(['foo', sym1]);
 
       e.removeListener('foo', foo);
 
-      assume(e.eventNames()).eql([s]);
+      assume(e.eventNames()).eql([sym1]);
     });
   });
 


### PR DESCRIPTION
This patch updates the `eventNames` method to make it exclude the symbol properties that are non-enumerable.