### PR TITLE
Improve `removeListener` performance

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ EventEmitter.prototype.emit = function emit(event, a1, a2, a3, a4, a5) {
     , args
     , i;
 
-  if ('function' === typeof listeners.fn) {
+  if (listeners.fn) {
     if (listeners.once) this.removeListener(event, listeners.fn, undefined, true);
 
     switch (len) {

--- a/index.js
+++ b/index.js
@@ -210,39 +210,37 @@ EventEmitter.prototype.removeListener = function removeListener(event, fn, conte
   var evt = prefix ? prefix + event : event;
 
   if (!this._events || !this._events[evt]) return this;
+  if (!fn) return delete this._events[evt], this;
 
-  var listeners = this._events[evt]
-    , events = [];
+  var listeners = this._events[evt];
 
-  if (fn) {
-    if (listeners.fn) {
+  if (listeners.fn) {
+    if (
+         listeners.fn === fn
+      && (!once || listeners.once)
+      && (!context || listeners.context === context)
+    ) {
+      delete this._events[evt];
+    }
+  } else {
+    for (var i = 0, events = [], length = listeners.length; i < length; i++) {
       if (
-           listeners.fn !== fn
-        || (once && !listeners.once)
-        || (context && listeners.context !== context)
+           listeners[i].fn !== fn
+        || (once && !listeners[i].once)
+        || (context && listeners[i].context !== context)
       ) {
-        events.push(listeners);
-      }
-    } else {
-      for (var i = 0, length = listeners.length; i < length; i++) {
-        if (
-             listeners[i].fn !== fn
-          || (once && !listeners[i].once)
-          || (context && listeners[i].context !== context)
-        ) {
-          events.push(listeners[i]);
-        }
+        events.push(listeners[i]);
       }
     }
-  }
 
-  //
-  // Reset the array, or remove it completely if we have no more listeners.
-  //
-  if (events.length) {
-    this._events[evt] = events.length === 1 ? events[0] : events;
-  } else {
-    delete this._events[evt];
+    //
+    // Reset the array, or remove it completely if we have no more listeners.
+    //
+    if (events.length) {
+      this._events[evt] = events.length === 1 ? events[0] : events;
+    } else {
+      delete this._events[evt];
+    }
   }
 
   return this;


### PR DESCRIPTION
This sligtly improves the `removeListener` performance when there is only one listener.

Result of `once.js` benchmark:

```
log:      Finished benchmarking: "EventEmitter3@1.2.0"
metric:   Count (51502), Cycles (5), Elapsed (5.592), Hz (913621.98)
log:      Finished benchmarking: "EventEmitter3(master)"
metric:   Count (55202), Cycles (4), Elapsed (5.583), Hz (978589.2)
info:     Benchmark: "EventEmitter3(master)" is the fastest.
```

Result of `listening.js` benchmark:

```
log:      Finished benchmarking: "EventEmitter3@1.2.0"
metric:   Count (58987), Cycles (5), Elapsed (5.745), Hz (1090032.06)
log:      Finished benchmarking: "EventEmitter3(master)"
metric:   Count (64261), Cycles (9), Elapsed (5.706), Hz (1181078.63)
info:     Benchmark: "EventEmitter3(master)" is the fastest.
```