### PR TITLE
Make benchmarks results easier to read

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,189 +1,121 @@
-Starting benchmark run/remove-emit.js
+Starting benchmark listeners.js
 
 ```
-log:      Finished benchmarking: "EventEmitter1"
-metric:   Count (300141), Cycles (7), Elapsed (5.485), Hz (5766727.97)
-log:      Finished benchmarking: "EventEmitter2"
-metric:   Count (239930), Cycles (9), Elapsed (5.533), Hz (4596532.2)
-log:      Finished benchmarking: "EventEmitter3@0.1.6"
-metric:   Count (245874), Cycles (8), Elapsed (5.531), Hz (4672592.64)
-log:      Finished benchmarking: "EventEmitter3(master)"
-metric:   Count (246286), Cycles (7), Elapsed (5.496), Hz (4638523.64)
-log:      Finished benchmarking: "Drip"
-metric:   Count (357963), Cycles (7), Elapsed (5.497), Hz (6767097.99)
-log:      Finished benchmarking: "fastemitter"
-metric:   Count (0), Cycles (0), Elapsed (0), Hz (0)
-log:      Finished benchmarking: "event-emitter"
-metric:   Count (111401), Cycles (4), Elapsed (5.481), Hz (2112567.79)
-log:      Finished benchmarking: "contra/emitter"
-metric:   Count (5436), Cycles (5), Elapsed (5.422), Hz (103108.18)
-info:     Benchmark: "Drip" is the fastest.
+EventEmitter1 x 8,419,817 ops/sec ±0.73% (87 runs sampled)
+fastemitter x 5,097,101 ops/sec ±0.63% (86 runs sampled)
+EventEmitter3@0.1.6 x 8,176,776 ops/sec ±1.63% (84 runs sampled)
+EventEmitter3(master) x 8,587,370 ops/sec ±0.68% (87 runs sampled)
+Fastest is EventEmitter3(master)
 ```
 
-Starting benchmark run/context.js
+Starting benchmark listening.js
 
 ```
-log:      Finished benchmarking: "EventEmitter1"
-metric:   Count (63780), Cycles (7), Elapsed (5.505), Hz (1218532.19)
-log:      Finished benchmarking: "EventEmitter2"
-metric:   Count (60361), Cycles (6), Elapsed (5.442), Hz (1168465.4)
-log:      Finished benchmarking: "EventEmitter3@0.1.6"
-metric:   Count (641986), Cycles (6), Elapsed (5.402), Hz (12565337.33)
-log:      Finished benchmarking: "EventEmitter3(master)"
-metric:   Count (610424), Cycles (7), Elapsed (5.483), Hz (11822617.33)
-log:      Finished benchmarking: "Drip"
-metric:   Count (60685), Cycles (10), Elapsed (5.607), Hz (1168841.57)
-log:      Finished benchmarking: "fastemitter"
-metric:   Count (57613), Cycles (6), Elapsed (5.531), Hz (1121652.43)
-log:      Finished benchmarking: "event-emitter"
-metric:   Count (45978), Cycles (6), Elapsed (5.474), Hz (888976.81)
-log:      Finished benchmarking: "contra/emitter"
-metric:   Count (4512), Cycles (7), Elapsed (5.492), Hz (86561.56)
-info:     Benchmark: "EventEmitter3@0.1.6" is the fastest.
+EventEmitter1 x 5,334,568 ops/sec ±1.95% (86 runs sampled)
+EventEmitter2 x 1,201,955 ops/sec ±1.04% (87 runs sampled)
+EventEmitter3@0.1.6 x 1,818,137 ops/sec ±1.19% (87 runs sampled)
+EventEmitter3(master) x 17,757,833 ops/sec ±6.12% (83 runs sampled)
+Drip x 29,877,925 ops/sec ±0.62% (88 runs sampled)
+fastemitter x 11,711,552 ops/sec ±0.70% (91 runs sampled)
+event-emitter x 1,742,494 ops/sec ±1.42% (88 runs sampled)
+contra/emitter x 4,728,271 ops/sec ±1.03% (85 runs sampled)
+Fastest is Drip
 ```
 
-Starting benchmark run/emit.js
+Starting benchmark init.js
 
 ```
-log:      Finished benchmarking: "EventEmitter1"
-metric:   Count (491710), Cycles (5), Elapsed (5.575), Hz (9350733.44)
-log:      Finished benchmarking: "EventEmitter2"
-metric:   Count (358006), Cycles (7), Elapsed (5.608), Hz (6917207.93)
-log:      Finished benchmarking: "EventEmitter3@0.1.6"
-metric:   Count (635957), Cycles (8), Elapsed (5.47), Hz (12174427.75)
-log:      Finished benchmarking: "EventEmitter3(master)"
-metric:   Count (611044), Cycles (5), Elapsed (5.385), Hz (11467928.93)
-log:      Finished benchmarking: "Drip"
-metric:   Count (354774), Cycles (8), Elapsed (5.488), Hz (6746871.4)
-log:      Finished benchmarking: "fastemitter"
-metric:   Count (285710), Cycles (7), Elapsed (5.512), Hz (5401655.5)
-log:      Finished benchmarking: "event-emitter"
-metric:   Count (135697), Cycles (4), Elapsed (5.438), Hz (2571125.67)
-log:      Finished benchmarking: "contra/emitter"
-metric:   Count (5513), Cycles (5), Elapsed (5.526), Hz (104834.15)
-info:     Benchmark: "EventEmitter3@0.1.6" is the fastest.
+EventEmitter1 x 38,367,345 ops/sec ±0.75% (90 runs sampled)
+EventEmitter2 x 42,150,995 ops/sec ±0.66% (90 runs sampled)
+EventEmitter3@0.1.6 x 99,292,086 ops/sec ±1.19% (90 runs sampled)
+EventEmitter3(master) x 95,929,464 ops/sec ±0.67% (87 runs sampled)
+Drip x 100,110,205 ops/sec ±0.88% (86 runs sampled)
+fastemitter x 11,818,881 ops/sec ±0.85% (91 runs sampled)
+event-emitter x 460,349 ops/sec ±0.71% (91 runs sampled)
+contra/emitter x 744,836 ops/sec ±5.10% (57 runs sampled)
+Fastest is Drip,EventEmitter3@0.1.6
 ```
 
-Starting benchmark run/listeners.js
+Starting benchmark remove-emit.js
 
 ```
-log:      Finished benchmarking: "EventEmitter1"
-metric:   Count (593534), Cycles (6), Elapsed (5.467), Hz (11496807.4)
-log:      Finished benchmarking: "fastemitter"
-metric:   Count (335254), Cycles (4), Elapsed (5.489), Hz (6477042.13)
-log:      Finished benchmarking: "EventEmitter3@0.1.6"
-metric:   Count (263872), Cycles (4), Elapsed (5.533), Hz (5127778.92)
-log:      Finished benchmarking: "EventEmitter3(master)"
-metric:   Count (531368), Cycles (4), Elapsed (5.375), Hz (10111356.8)
-info:     Benchmark: "EventEmitter1" is the fastest.
+EventEmitter1 x 4,534,152 ops/sec ±0.26% (90 runs sampled)
+EventEmitter2 x 1,917,124 ops/sec ±0.57% (91 runs sampled)
+EventEmitter3@0.1.6 x 3,669,473 ops/sec ±0.34% (85 runs sampled)
+EventEmitter3(master) x 3,662,612 ops/sec ±0.30% (92 runs sampled)
+Drip x 2,307,264 ops/sec ±0.58% (86 runs sampled)
+fastemitter:
+event-emitter x 1,366,291 ops/sec ±0.72% (90 runs sampled)
+contra/emitter x 66,641 ops/sec ±0.70% (91 runs sampled)
+Fastest is EventEmitter1
 ```
 
-Starting benchmark run/init.js
+Starting benchmark multiple-emitters.js
 
 ```
-log:      Finished benchmarking: "EventEmitter1"
-metric:   Count (2371903), Cycles (5), Elapsed (5.391), Hz (46101979.59)
-log:      Finished benchmarking: "EventEmitter2"
-metric:   Count (2762751), Cycles (4), Elapsed (5.321), Hz (52770261.7)
-log:      Finished benchmarking: "EventEmitter3@0.1.6"
-metric:   Count (6391324), Cycles (4), Elapsed (5.304), Hz (125119847.85)
-log:      Finished benchmarking: "EventEmitter3(master)"
-metric:   Count (6385547), Cycles (4), Elapsed (5.305), Hz (122219853.56)
-log:      Finished benchmarking: "Drip"
-metric:   Count (6509454), Cycles (4), Elapsed (5.365), Hz (126618722.15)
-log:      Finished benchmarking: "fastemitter"
-metric:   Count (955184), Cycles (7), Elapsed (5.609), Hz (18682885.18)
-log:      Finished benchmarking: "event-emitter"
-metric:   Count (12248), Cycles (4), Elapsed (5.466), Hz (237939.18)
-log:      Finished benchmarking: "contra/emitter"
-metric:   Count (91125), Cycles (3), Elapsed (5.458), Hz (1466162.84)
-info:     Benchmark: "Drip" is the fastest.
+EventEmitter1 x 2,838,220 ops/sec ±0.46% (92 runs sampled)
+EventEmitter2 x 628,873 ops/sec ±0.78% (91 runs sampled)
+EventEmitter3@0.1.6 x 928,801 ops/sec ±0.84% (89 runs sampled)
+EventEmitter3(master) x 3,805,937 ops/sec ±0.19% (91 runs sampled)
+Drip:
+fastemitter x 1,043,290 ops/sec ±0.85% (92 runs sampled)
+event-emitter x 281,665 ops/sec ±0.71% (91 runs sampled)
+contra/emitter x 58,449 ops/sec ±0.73% (88 runs sampled)
+Fastest is EventEmitter3(master)
 ```
 
-Starting benchmark run/once.js
+Starting benchmark context.js
 
 ```
-log:      Finished benchmarking: "EventEmitter1"
-metric:   Count (244173), Cycles (6), Elapsed (5.598), Hz (4646107.77)
-log:      Finished benchmarking: "EventEmitter2"
-metric:   Count (74973), Cycles (7), Elapsed (5.467), Hz (1406731.22)
-log:      Finished benchmarking: "EventEmitter3@0.1.6"
-metric:   Count (121604), Cycles (7), Elapsed (5.77), Hz (2294819.86)
-log:      Finished benchmarking: "EventEmitter3(master)"
-metric:   Count (111839), Cycles (5), Elapsed (5.343), Hz (2072445.8)
-log:      Finished benchmarking: "Drip"
-metric:   Count (362602), Cycles (5), Elapsed (5.417), Hz (6743602.42)
-log:      Finished benchmarking: "fastemitter"
-metric:   Count (295873), Cycles (5), Elapsed (5.442), Hz (5711255.82)
-log:      Finished benchmarking: "event-emitter"
-metric:   Count (67064), Cycles (5), Elapsed (5.447), Hz (1266180.56)
-log:      Finished benchmarking: "contra/emitter"
-metric:   Count (23296), Cycles (5), Elapsed (5.574), Hz (436957.6)
-info:     Benchmark: "Drip" is the fastest.
+EventEmitter1 x 7,389,189 ops/sec ±0.32% (89 runs sampled)
+EventEmitter2 x 2,318,865 ops/sec ±0.85% (91 runs sampled)
+EventEmitter3@0.1.6 x 12,945,544 ops/sec ±0.27% (90 runs sampled)
+EventEmitter3(master) x 13,324,555 ops/sec ±0.42% (89 runs sampled)
+Drip x 2,336,146 ops/sec ±0.63% (92 runs sampled)
+fastemitter x 1,906,935 ops/sec ±0.66% (90 runs sampled)
+event-emitter x 1,643,746 ops/sec ±0.70% (89 runs sampled)
+contra/emitter x 66,454 ops/sec ±0.78% (83 runs sampled)
+Fastest is EventEmitter3(master)
 ```
 
-Starting benchmark run/multiple-emitters.js
+Starting benchmark once.js
 
 ```
-log:      Finished benchmarking: "EventEmitter1"
-metric:   Count (182871), Cycles (5), Elapsed (5.452), Hz (3557110.76)
-log:      Finished benchmarking: "EventEmitter2"
-metric:   Count (45337), Cycles (7), Elapsed (5.512), Hz (877344.25)
-log:      Finished benchmarking: "EventEmitter3@0.1.6"
-metric:   Count (143759), Cycles (4), Elapsed (5.389), Hz (2771580.78)
-log:      Finished benchmarking: "EventEmitter3(master)"
-metric:   Count (145497), Cycles (5), Elapsed (5.491), Hz (2780475.14)
-log:      Finished benchmarking: "Drip"
-metric:   Count (0), Cycles (0), Elapsed (0), Hz (0)
-log:      Finished benchmarking: "fastemitter"
-metric:   Count (140028), Cycles (7), Elapsed (5.626), Hz (2664390.63)
-log:      Finished benchmarking: "event-emitter"
-metric:   Count (35605), Cycles (5), Elapsed (5.519), Hz (685442.78)
-log:      Finished benchmarking: "contra/emitter"
-metric:   Count (4989), Cycles (5), Elapsed (5.447), Hz (93632.37)
-info:     Benchmark: "EventEmitter1" is the fastest.
+EventEmitter1 x 3,503,042 ops/sec ±0.99% (90 runs sampled)
+EventEmitter2 x 951,925 ops/sec ±2.12% (86 runs sampled)
+EventEmitter3@0.1.6 x 1,635,066 ops/sec ±1.88% (85 runs sampled)
+EventEmitter3(master) x 14,823,922 ops/sec ±4.32% (83 runs sampled)
+Drip x 7,371,417 ops/sec ±1.35% (92 runs sampled)
+fastemitter x 3,982,675 ops/sec ±0.88% (92 runs sampled)
+event-emitter x 1,108,597 ops/sec ±1.44% (85 runs sampled)
+contra/emitter x 284,999 ops/sec ±0.69% (88 runs sampled)
+Fastest is EventEmitter3(master)
 ```
 
-Starting benchmark run/hundreds.js
+Starting benchmark hundreds.js
 
 ```
-log:      Finished benchmarking: "EventEmitter1"
-metric:   Count (20350), Cycles (6), Elapsed (5.489), Hz (387624.02)
-log:      Finished benchmarking: "EventEmitter2"
-metric:   Count (8866), Cycles (3), Elapsed (5.355), Hz (170348.45)
-log:      Finished benchmarking: "EventEmitter3@0.1.6"
-metric:   Count (18433), Cycles (5), Elapsed (5.448), Hz (358090.16)
-log:      Finished benchmarking: "EventEmitter3(master)"
-metric:   Count (18120), Cycles (7), Elapsed (5.521), Hz (352318.05)
-log:      Finished benchmarking: "Drip"
-metric:   Count (24497), Cycles (7), Elapsed (5.524), Hz (473331.47)
-log:      Finished benchmarking: "fastemitter"
-metric:   Count (24421), Cycles (5), Elapsed (5.457), Hz (472979.48)
-log:      Finished benchmarking: "event-emitter"
-metric:   Count (8095), Cycles (5), Elapsed (5.604), Hz (157427.97)
-log:      Finished benchmarking: "contra/emitter"
-metric:   Count (2151), Cycles (7), Elapsed (5.636), Hz (41010.9)
-info:     Benchmark: "Drip,fastemitter" is the fastest.
+EventEmitter1 x 290,785 ops/sec ±0.56% (84 runs sampled)
+EventEmitter2 x 158,662 ops/sec ±0.75% (91 runs sampled)
+EventEmitter3@0.1.6 x 309,926 ops/sec ±0.45% (90 runs sampled)
+EventEmitter3(master) x 317,606 ops/sec ±0.48% (86 runs sampled)
+Drip x 350,993 ops/sec ±0.41% (91 runs sampled)
+fastemitter x 417,371 ops/sec ±0.47% (92 runs sampled)
+event-emitter x 141,263 ops/sec ±0.62% (91 runs sampled)
+contra/emitter x 22,070 ops/sec ±0.69% (90 runs sampled)
+Fastest is fastemitter
 ```
 
-Starting benchmark run/listening.js
+Starting benchmark emit.js
 
 ```
-log:      Finished benchmarking: "EventEmitter1"
-metric:   Count (587805), Cycles (7), Elapsed (5.571), Hz (11305119.11)
-log:      Finished benchmarking: "EventEmitter2"
-metric:   Count (108192), Cycles (6), Elapsed (5.555), Hz (2086559.09)
-log:      Finished benchmarking: "EventEmitter3@0.1.6"
-metric:   Count (136498), Cycles (7), Elapsed (5.487), Hz (2603701.52)
-log:      Finished benchmarking: "EventEmitter3(master)"
-metric:   Count (123469), Cycles (6), Elapsed (5.564), Hz (2368749.83)
-log:      Finished benchmarking: "Drip"
-metric:   Count (1582232), Cycles (7), Elapsed (5.517), Hz (30514861.04)
-log:      Finished benchmarking: "fastemitter"
-metric:   Count (952524), Cycles (5), Elapsed (5.575), Hz (18337197.08)
-log:      Finished benchmarking: "event-emitter"
-metric:   Count (103718), Cycles (4), Elapsed (5.414), Hz (2011935.8)
-log:      Finished benchmarking: "contra/emitter"
-metric:   Count (356517), Cycles (4), Elapsed (5.387), Hz (6918922.38)
-info:     Benchmark: "Drip" is the fastest.
+EventEmitter1 x 12,938,293 ops/sec ±0.34% (91 runs sampled)
+EventEmitter2 x 2,446,918 ops/sec ±0.86% (90 runs sampled)
+EventEmitter3@0.1.6 x 12,814,743 ops/sec ±0.43% (92 runs sampled)
+EventEmitter3(master) x 13,716,253 ops/sec ±0.34% (92 runs sampled)
+Drip x 2,387,781 ops/sec ±0.87% (90 runs sampled)
+fastemitter x 1,934,775 ops/sec ±0.80% (89 runs sampled)
+event-emitter x 1,716,995 ops/sec ±0.67% (90 runs sampled)
+contra/emitter x 62,678 ops/sec ±0.67% (91 runs sampled)
+Fastest is EventEmitter3(master)
 ```

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "benchmark": "2.1.x",
     "contra": "latest",
-    "devnull": "0.0.12",
     "drip": "latest",
     "event-emitter": "latest",
     "eventemitter2": "latest",

--- a/benchmarks/run/context.js
+++ b/benchmarks/run/context.js
@@ -6,11 +6,6 @@
 var benchmark = require('benchmark');
 
 /**
- * Logger.
- */
-var logger = new(require('devnull'))({ timestamp: false, namespacing: 0 });
-
-/**
  * Preparation code.
  */
 var EventEmitter2 = require('eventemitter2').EventEmitter2
@@ -21,6 +16,8 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
   , EE = require('event-emitter')
   , FE = require('fastemitter')
   , CE = require('contra/emitter');
+
+var ctx = { foo: 'bar' };
 
 function handle() {
   if (arguments.length > 100) console.log('damn');
@@ -38,14 +35,14 @@ var ee2 = new EventEmitter2()
   , ee = EE({})
   , ce = CE();
 
-ee3.on('foo', handle, logger);
-ee2.on('foo', handle.bind(logger));
-ee1.on('foo', handle.bind(logger));
-drip.on('foo', handle.bind(logger));
-master.on('foo', handle, logger);
-ee.on('foo', handle.bind(logger));
-fe.on('foo', handle.bind(logger));
-ce.on('foo', handle.bind(logger));
+ee3.on('foo', handle, ctx);
+ee2.on('foo', handle.bind(ctx));
+ee1.on('foo', handle.bind(ctx));
+drip.on('foo', handle.bind(ctx));
+master.on('foo', handle, ctx);
+ee.on('foo', handle.bind(ctx));
+fe.on('foo', handle.bind(ctx));
+ce.on('foo', handle.bind(ctx));
 
 (
   new benchmark.Suite()
@@ -90,17 +87,7 @@ ce.on('foo', handle.bind(logger));
   ce.emit('foo', 'bar', 'baz');
   ce.emit('foo', 'bar', 'baz', 'boom');
 }).on('cycle', function cycle(e) {
-  var details = e.target;
-
-  logger.log('Finished benchmarking: "%s"', details.name);
-  logger.metric('Count (%d), Cycles (%d), Elapsed (%d), Hz (%d)'
-    , details.count
-    , details.cycles
-    , details.times.elapsed
-    , details.hz.toFixed(2)
-  );
+  console.log(e.target.toString());
 }).on('complete', function completed() {
-  logger.info('Benchmark: "%s" is the fastest.'
-    , this.filter('fastest').map('name')
-  );
-}).run();
+  console.log('Fastest is %s', this.filter('fastest').map('name'));
+}).run({ async: true });

--- a/benchmarks/run/emit.js
+++ b/benchmarks/run/emit.js
@@ -6,11 +6,6 @@
 var benchmark = require('benchmark');
 
 /**
- * Logger.
- */
-var logger = new(require('devnull'))({ timestamp: false, namespacing: 0 });
-
-/**
  * Preparation code.
  */
 var EventEmitter2 = require('eventemitter2').EventEmitter2
@@ -90,17 +85,7 @@ ce.on('foo', handle);
   ce.emit('foo', 'bar', 'baz');
   ce.emit('foo', 'bar', 'baz', 'boom');
 }).on('cycle', function cycle(e) {
-  var details = e.target;
-
-  logger.log('Finished benchmarking: "%s"', details.name);
-  logger.metric('Count (%d), Cycles (%d), Elapsed (%d), Hz (%d)'
-    , details.count
-    , details.cycles
-    , details.times.elapsed
-    , details.hz.toFixed(2)
-  );
+  console.log(e.target.toString());
 }).on('complete', function completed() {
-  logger.info('Benchmark: "%s" is the fastest.'
-    , this.filter('fastest').map('name')
-  );
-}).run();
+  console.log('Fastest is %s', this.filter('fastest').map('name'));
+}).run({ async: true });

--- a/benchmarks/run/hundreds.js
+++ b/benchmarks/run/hundreds.js
@@ -6,11 +6,6 @@
 var benchmark = require('benchmark');
 
 /**
- * Logger.
- */
-var logger = new(require('devnull'))({ timestamp: false, namespacing: 0 });
-
-/**
  * Preparation code.
  */
 var EventEmitter2 = require('eventemitter2').EventEmitter2
@@ -89,17 +84,7 @@ for (i = 0; i < 10; i++) {
     ce.emit('event:' + i);
   }
 }).on('cycle', function cycle(e) {
-  var details = e.target;
-
-  logger.log('Finished benchmarking: "%s"', details.name);
-  logger.metric('Count (%d), Cycles (%d), Elapsed (%d), Hz (%d)'
-    , details.count
-    , details.cycles
-    , details.times.elapsed
-    , details.hz.toFixed(2)
-  );
+  console.log(e.target.toString());
 }).on('complete', function completed() {
-  logger.info('Benchmark: "%s" is the fastest.'
-    , this.filter('fastest').map('name')
-  );
-}).run();
+  console.log('Fastest is %s', this.filter('fastest').map('name'));
+}).run({ async: true });

--- a/benchmarks/run/init.js
+++ b/benchmarks/run/init.js
@@ -6,11 +6,6 @@
 var benchmark = require('benchmark');
 
 /**
- * Logger.
- */
-var logger = new(require('devnull'))({ timestamp: false, namespacing: 0 });
-
-/**
  * Preparation code.
  */
 var EventEmitter2 = require('eventemitter2').EventEmitter2
@@ -41,17 +36,7 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
 }).add('contra/emitter', function() {
   CE();
 }).on('cycle', function cycle(e) {
-  var details = e.target;
-
-  logger.log('Finished benchmarking: "%s"', details.name);
-  logger.metric('Count (%d), Cycles (%d), Elapsed (%d), Hz (%d)'
-    , details.count
-    , details.cycles
-    , details.times.elapsed
-    , details.hz.toFixed(2)
-  );
+  console.log(e.target.toString());
 }).on('complete', function completed() {
-  logger.info('Benchmark: "%s" is the fastest.'
-    , this.filter('fastest').map('name')
-  );
-}).run();
+  console.log('Fastest is %s', this.filter('fastest').map('name'));
+}).run({ async: true });

--- a/benchmarks/run/listeners.js
+++ b/benchmarks/run/listeners.js
@@ -6,11 +6,6 @@
 var benchmark = require('benchmark');
 
 /**
- * Logger.
- */
-var logger = new(require('devnull'))({ timestamp: false, namespacing: 0 });
-
-/**
  * Preparation code.
  */
 var EventEmitter3 = require('eventemitter3')
@@ -60,17 +55,7 @@ for (var i = 0; i < 25; i++) {
 }).add('EventEmitter3(master)', function() {
   master.listeners('event');
 }).on('cycle', function cycle(e) {
-  var details = e.target;
-
-  logger.log('Finished benchmarking: "%s"', details.name);
-  logger.metric('Count (%d), Cycles (%d), Elapsed (%d), Hz (%d)'
-    , details.count
-    , details.cycles
-    , details.times.elapsed
-    , details.hz.toFixed(2)
-  );
+  console.log(e.target.toString());
 }).on('complete', function completed() {
-  logger.info('Benchmark: "%s" is the fastest.'
-    , this.filter('fastest').map('name')
-  );
-}).run();
+  console.log('Fastest is %s', this.filter('fastest').map('name'));
+}).run({ async: true });

--- a/benchmarks/run/listening.js
+++ b/benchmarks/run/listening.js
@@ -6,11 +6,6 @@
 var benchmark = require('benchmark');
 
 /**
- * Logger.
- */
-var logger = new(require('devnull'))({ timestamp: false, namespacing: 0 });
-
-/**
  * Preparation code.
  */
 var EventEmitter2 = require('eventemitter2').EventEmitter2
@@ -65,17 +60,7 @@ var ee2 = new EventEmitter2()
   ce.on('foo', handle);
   ce.off('foo', handle);
 }).on('cycle', function cycle(e) {
-  var details = e.target;
-
-  logger.log('Finished benchmarking: "%s"', details.name);
-  logger.metric('Count (%d), Cycles (%d), Elapsed (%d), Hz (%d)'
-    , details.count
-    , details.cycles
-    , details.times.elapsed
-    , details.hz.toFixed(2)
-  );
+  console.log(e.target.toString());
 }).on('complete', function completed() {
-  logger.info('Benchmark: "%s" is the fastest.'
-    , this.filter('fastest').map('name')
-  );
-}).run();
+  console.log('Fastest is %s', this.filter('fastest').map('name'));
+}).run({ async: true });

--- a/benchmarks/run/multiple-emitters.js
+++ b/benchmarks/run/multiple-emitters.js
@@ -6,11 +6,6 @@
 var benchmark = require('benchmark');
 
 /**
- * Logger.
- */
-var logger = new(require('devnull'))({ timestamp: false, namespacing: 0 });
-
-/**
  * Preparation code.
  */
 var EventEmitter2 = require('eventemitter2').EventEmitter2
@@ -104,17 +99,7 @@ master.on('foo', foo).on('foo', bar).on('foo', baz);
   ce.emit('foo', 'bar', 'baz');
   ce.emit('foo', 'bar', 'baz', 'boom');
 }).on('cycle', function cycle(e) {
-  var details = e.target;
-
-  logger.log('Finished benchmarking: "%s"', details.name);
-  logger.metric('Count (%d), Cycles (%d), Elapsed (%d), Hz (%d)'
-    , details.count
-    , details.cycles
-    , details.times.elapsed
-    , details.hz.toFixed(2)
-  );
+  console.log(e.target.toString());
 }).on('complete', function completed() {
-  logger.info('Benchmark: "%s" is the fastest.'
-    , this.filter('fastest').map('name')
-  );
-}).run();
+  console.log('Fastest is %s', this.filter('fastest').map('name'));
+}).run({ async: true });

--- a/benchmarks/run/once.js
+++ b/benchmarks/run/once.js
@@ -6,11 +6,6 @@
 var benchmark = require('benchmark');
 
 /**
- * Logger.
- */
-var logger = new(require('devnull'))({ timestamp: false, namespacing: 0 });
-
-/**
  * Preparation code.
  */
 var EventEmitter2 = require('eventemitter2').EventEmitter2
@@ -57,17 +52,7 @@ var ee2 = new EventEmitter2()
 }).add('contra/emitter', function() {
   ce.once('foo', handle).emit('foo');
 }).on('cycle', function cycle(e) {
-  var details = e.target;
-
-  logger.log('Finished benchmarking: "%s"', details.name);
-  logger.metric('Count (%d), Cycles (%d), Elapsed (%d), Hz (%d)'
-    , details.count
-    , details.cycles
-    , details.times.elapsed
-    , details.hz.toFixed(2)
-  );
+  console.log(e.target.toString());
 }).on('complete', function completed() {
-  logger.info('Benchmark: "%s" is the fastest.'
-    , this.filter('fastest').map('name')
-  );
-}).run();
+  console.log('Fastest is %s', this.filter('fastest').map('name'));
+}).run({ async: true });

--- a/benchmarks/run/remove-emit.js
+++ b/benchmarks/run/remove-emit.js
@@ -6,11 +6,6 @@
 var benchmark = require('benchmark');
 
 /**
- * Logger.
- */
-var logger = new(require('devnull'))({ timestamp: false, namespacing: 0 });
-
-/**
  * Preparation code.
  */
 var EventEmitter2 = require('eventemitter2').EventEmitter2
@@ -47,7 +42,7 @@ var ee2 = new EventEmitter2()
   //
   emitter.on('ohai', ohai);
   if (emitter.removeListener) emitter.removeListener('ohai', ohai);
-  else if(emitter.off) emitter.off('ohai', ohai);
+  else if (emitter.off) emitter.off('ohai', ohai);
   else throw new Error('No proper remove implementation');
 });
 
@@ -94,17 +89,7 @@ var ee2 = new EventEmitter2()
   ce.emit('foo', 'bar', 'baz');
   ce.emit('foo', 'bar', 'baz', 'boom');
 }).on('cycle', function cycle(e) {
-  var details = e.target;
-
-  logger.log('Finished benchmarking: "%s"', details.name);
-  logger.metric('Count (%d), Cycles (%d), Elapsed (%d), Hz (%d)'
-    , details.count
-    , details.cycles
-    , details.times.elapsed
-    , details.hz.toFixed(2)
-  );
+  console.log(e.target.toString());
 }).on('complete', function completed() {
-  logger.info('Benchmark: "%s" is the fastest.'
-    , this.filter('fastest').map('name')
-  );
-}).run();
+  console.log('Fastest is %s', this.filter('fastest').map('name'));
+}).run({ async: true });

--- a/benchmarks/template.js
+++ b/benchmarks/template.js
@@ -6,11 +6,6 @@
 var benchmark = require('benchmark');
 
 /**
- * Logger.
- */
-var logger = new(require('devnull'))({ timestamp: false, namespacing: 0 });
-
-/**
  * Preparation code.
  */
 
@@ -21,17 +16,7 @@ var logger = new(require('devnull'))({ timestamp: false, namespacing: 0 });
 }).add('<test2>', function() {
 
 }).on('cycle', function cycle(e) {
-  var details = e.target;
-
-  logger.log('Finished benchmarking: "%s"', details.name);
-  logger.metric('Count (%d), Cycles (%d), Elapsed (%d), Hz (%d)'
-    , details.count
-    , details.cycles
-    , details.times.elapsed
-    , details.hz.toFixed(2)
-  );
+  console.log(e.target.toString());
 }).on('complete', function completed() {
-  logger.info('Benchmark: "%s" is the fastest.'
-    , this.filter('fastest').map('name')
-  );
-}).run();
+  console.log('Fastest is %s', this.filter('fastest').map('name'));
+}).run({ async: true });


### PR DESCRIPTION
- Make the benchmarks results easier to read by only showing ops/sec
- Remove the `devnull` dependency in favor of `console.log`
- Update [`benchmarks/README.md`](https://github.com/primus/eventemitter3/blob/e2c2248596161ba5005b7bdd93da58a0e9a4709b/benchmarks/README.md) with fresh data