### PR TITLE
Expose eventemitter3 for ES6-style imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -303,5 +303,7 @@ EventEmitter.prefixed = prefix;
 //
 if ('undefined' !== typeof module) {
   module.exports = EventEmitter;
-  module.exports.EventEmitter = EventEmitter;
+
+  // Allow EventEmitter to be imported as module namespace
+  EventEmitter.EventEmitter = EventEmitter;
 }

--- a/index.js
+++ b/index.js
@@ -303,4 +303,5 @@ EventEmitter.prefixed = prefix;
 //
 if ('undefined' !== typeof module) {
   module.exports = EventEmitter;
+  module.exports.EventEmitter = EventEmitter;
 }

--- a/test.js
+++ b/test.js
@@ -9,6 +9,10 @@ describe('EventEmitter', function tests() {
     assume(EventEmitter.prefixed).is.either([false, '~']);
   });
 
+  it('exposes a module namespace object', function() {
+    assume(EventEmitter.EventEmitter).equals(EventEmitter);
+  });
+
   it('inherits when used with `require("util").inherits`', function () {
     function Beast() {
       EventEmitter.call(this);


### PR DESCRIPTION
The `module.exports = someFunction` pattern is incompatible with ES6 imports. This change allows ES6-compatible environments (such as TypeScript or Babel) to import eventemitter3:

``` js
import { EventEmitter } from 'eventemitter3';
```