### PR TITLE
TypeScript Bindings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,8 +18,8 @@ export class EventEmitter {
   /**
    * Return the listeners registered for a given event.
    */
-  listeners(event: string | symbol): Array<ListenerFn>;
   listeners(event: string | symbol, exists: boolean): Array<ListenerFn> | boolean;
+  listeners(event: string | symbol): Array<ListenerFn>;
 
   /**
    * Calls each of the listeners registered for a given event.

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ type ListenerFn = (...args: Array<any>) => void;
  * `EventEmitter` interface.
  */
 export class EventEmitter {
-  prefix: string;
+  prefixed: string;
 
   /**
    * Return an array listing the events for which the emitter has registered
@@ -29,22 +29,22 @@ export class EventEmitter {
   /**
    * Add a listener for a given event.
    */
-  on(event: string | symbol, fn: ListenerFn, context?: any): EventEmitter;
-  addListener(event: string | symbol, fn: ListenerFn, context?: any): EventEmitter;
+  on(event: string | symbol, fn: ListenerFn, context?: any): this;
+  addListener(event: string | symbol, fn: ListenerFn, context?: any): this;
 
   /**
    * Add a one-time listener for a given event.
    */
-  once(event: string | symbol, fn: ListenerFn, context?: any): EventEmitter;
+  once(event: string | symbol, fn: ListenerFn, context?: any): this;
 
   /**
    * Remove the listeners of a given event.
    */
-  removeListener(event: string | symbol, fn?: ListenerFn, context?: any, once?: boolean): EventEmitter;
-  off(event: string | symbol, fn?: ListenerFn, context?: any, once?: boolean): EventEmitter;
+  removeListener(event: string | symbol, fn?: ListenerFn, context?: any, once?: boolean): this;
+  off(event: string | symbol, fn?: ListenerFn, context?: any, once?: boolean): this;
 
   /**
    * Remove all listeners, or those of the specified event.
    */
-  removeAllListeners(event?: string | symbol): EventEmitter;
+  removeAllListeners(event?: string | symbol): this;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ type ListenerFn = (...args: Array<any>) => void;
  * `EventEmitter` interface.
  */
 export class EventEmitter {
-  prefixed: string;
+  static prefixed: string | boolean;
 
   /**
    * Return an array listing the events for which the emitter has registered

--- a/index.d.ts
+++ b/index.d.ts
@@ -46,5 +46,5 @@ export class EventEmitter {
   /**
    * Remove all listeners, or those of the specified event.
    */
-  removeAllListeners(event: string | symbol): EventEmitter;
+  removeAllListeners(event?: string | symbol): EventEmitter;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,48 +3,48 @@ export as namespace EventEmitter;
 type ListenerFn = (...args: Array<any>) => void;
 
 /**
-  * Minimal `EventEmitter` interface that is molded against the Node.js
-  * `EventEmitter` interface.
-  */
+ * Minimal `EventEmitter` interface that is molded against the Node.js
+ * `EventEmitter` interface.
+ */
 export class EventEmitter {
   prefix: string;
 
   /**
-    * Return an array listing the events for which the emitter has registered
-    * listeners.
-    */
+   * Return an array listing the events for which the emitter has registered
+   * listeners.
+   */
   eventNames(): Array<string | symbol>;
 
   /**
-    * Return the listeners registered for a given event.
-    */
+   * Return the listeners registered for a given event.
+   */
   listeners(event: string | symbol): Array<ListenerFn>;
   listeners(event: string | symbol, exists: boolean): Array<ListenerFn> | boolean;
 
   /**
-    * Calls each of the listeners registered for a given event.
-    */
+   * Calls each of the listeners registered for a given event.
+   */
   emit(event: string | symbol, ...args: Array<any>): boolean;
 
   /**
-    * Add a listener for a given event.
-    */
+   * Add a listener for a given event.
+   */
   on(event: string | symbol, fn: ListenerFn, context?: any): EventEmitter;
   addListener(event: string | symbol, fn: ListenerFn, context?: any): EventEmitter;
 
   /**
-    * Add a one-time listener for a given event.
-    */
+   * Add a one-time listener for a given event.
+   */
   once(event: string | symbol, fn: ListenerFn, context?: any): EventEmitter;
 
   /**
-    * Remove the listeners of a given event.
-    */
+   * Remove the listeners of a given event.
+   */
   removeListener(event: string | symbol, fn?: ListenerFn, context?: any, once?: boolean): EventEmitter;
   off(event: string | symbol, fn?: ListenerFn, context?: any, once?: boolean): EventEmitter;
 
   /**
-    * Remove all listeners, or those of the specified event.
-    */
+   * Remove all listeners, or those of the specified event.
+   */
   removeAllListeners(event: string | symbol): EventEmitter;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,51 @@
+declare module 'eventemitter3' {
+
+  /**
+   * Minimal `EventEmitter` interface that is molded against the Node.js
+   * `EventEmitter` interface.
+   */
+  export class EventEmitter {
+    prefix: string;
+
+    /**
+     * Return an array listing the events for which the emitter has registered
+     * listeners.
+     */
+    eventNames(): Array<string | symbol>;
+
+    /**
+     * Return the listeners registered for a given event.
+     */
+    listeners(event: string | symbol): Array<ListenerFn>;
+    listeners(event: string | symbol, exists: boolean): Array<ListenerFn> | boolean;
+
+    /**
+     * Calls each of the listeners registered for a given event.
+     */
+    emit(event: string | symbol, ...args: Array<any>): boolean;
+
+    /**
+     * Add a listener for a given event.
+     */
+    on(event: string | symbol, fn: ListenerFn, context?: any): EventEmitter;
+    addListener(event: string | symbol, fn: ListenerFn, context?: any): EventEmitter;
+
+    /**
+     * Add a one-time listener for a given event.
+     */
+    once(event: string | symbol, fn: ListenerFn, context?: any): EventEmitter;
+
+    /**
+     * Remove the listeners of a given event.
+     */
+    removeListener(event: string | symbol, fn?: ListenerFn, context?: any, once?: boolean): EventEmitter;
+    off(event: string | symbol, fn?: ListenerFn, context?: any, once?: boolean): EventEmitter;
+
+    /**
+     * Remove all listeners, or those of the specified event.
+     */
+    removeAllListeners(event: string | symbol): EventEmitter;
+  }
+}
+
+type ListenerFn = (...args: Array<any>) => void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,51 +1,50 @@
-declare module 'eventemitter3' {
-
-  /**
-   * Minimal `EventEmitter` interface that is molded against the Node.js
-   * `EventEmitter` interface.
-   */
-  export class EventEmitter {
-    prefix: string;
-
-    /**
-     * Return an array listing the events for which the emitter has registered
-     * listeners.
-     */
-    eventNames(): Array<string | symbol>;
-
-    /**
-     * Return the listeners registered for a given event.
-     */
-    listeners(event: string | symbol): Array<ListenerFn>;
-    listeners(event: string | symbol, exists: boolean): Array<ListenerFn> | boolean;
-
-    /**
-     * Calls each of the listeners registered for a given event.
-     */
-    emit(event: string | symbol, ...args: Array<any>): boolean;
-
-    /**
-     * Add a listener for a given event.
-     */
-    on(event: string | symbol, fn: ListenerFn, context?: any): EventEmitter;
-    addListener(event: string | symbol, fn: ListenerFn, context?: any): EventEmitter;
-
-    /**
-     * Add a one-time listener for a given event.
-     */
-    once(event: string | symbol, fn: ListenerFn, context?: any): EventEmitter;
-
-    /**
-     * Remove the listeners of a given event.
-     */
-    removeListener(event: string | symbol, fn?: ListenerFn, context?: any, once?: boolean): EventEmitter;
-    off(event: string | symbol, fn?: ListenerFn, context?: any, once?: boolean): EventEmitter;
-
-    /**
-     * Remove all listeners, or those of the specified event.
-     */
-    removeAllListeners(event: string | symbol): EventEmitter;
-  }
-}
+export as namespace EventEmitter;
 
 type ListenerFn = (...args: Array<any>) => void;
+
+/**
+  * Minimal `EventEmitter` interface that is molded against the Node.js
+  * `EventEmitter` interface.
+  */
+export class EventEmitter {
+  prefix: string;
+
+  /**
+    * Return an array listing the events for which the emitter has registered
+    * listeners.
+    */
+  eventNames(): Array<string | symbol>;
+
+  /**
+    * Return the listeners registered for a given event.
+    */
+  listeners(event: string | symbol): Array<ListenerFn>;
+  listeners(event: string | symbol, exists: boolean): Array<ListenerFn> | boolean;
+
+  /**
+    * Calls each of the listeners registered for a given event.
+    */
+  emit(event: string | symbol, ...args: Array<any>): boolean;
+
+  /**
+    * Add a listener for a given event.
+    */
+  on(event: string | symbol, fn: ListenerFn, context?: any): EventEmitter;
+  addListener(event: string | symbol, fn: ListenerFn, context?: any): EventEmitter;
+
+  /**
+    * Add a one-time listener for a given event.
+    */
+  once(event: string | symbol, fn: ListenerFn, context?: any): EventEmitter;
+
+  /**
+    * Remove the listeners of a given event.
+    */
+  removeListener(event: string | symbol, fn?: ListenerFn, context?: any, once?: boolean): EventEmitter;
+  off(event: string | symbol, fn?: ListenerFn, context?: any, once?: boolean): EventEmitter;
+
+  /**
+    * Remove all listeners, or those of the specified event.
+    */
+  removeAllListeners(event: string | symbol): EventEmitter;
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.1",
   "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
   "main": "index.js",
+  "typings": "index.d.ts",
   "scripts": {
     "benchmark": "find benchmarks/run -name '*.js' -exec benchmarks/start.sh {} \\;",
     "test-node": "istanbul cover _mocha --report lcovonly -- test.js",


### PR DESCRIPTION
This pull request adds TypeScript bindings for the public interface of eventemitter3 (See issue #67).

The typings were written in the UMD style - that is, they will work correctly for scripts using module loaders as well as for scripts that reference `EventEmitter` as a global.