### PR TITLE
default export EventEmitter class

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ type ListenerFn = (...args: Array<any>) => void;
  * Minimal `EventEmitter` interface that is molded against the Node.js
  * `EventEmitter` interface.
  */
-export class EventEmitter {
+export default class EventEmitter {
   static prefixed: string | boolean;
 
   /**


### PR DESCRIPTION
Use export default for EventEmitter class to be in sync with the actual code which exports default using module.exports = EventEmitter. Fixes #95 