### PR TITLE
[minor] Reduce code without loss of performance

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,7 +171,7 @@ EventEmitter.prototype.emit = function emit(event, a1, a2, a3, a4, a5) {
   var listeners = this._events[evt]
     , len = arguments.length
     , args
-    , i;
+    , i = 0;
 
   if (listeners.fn) {
     if (listeners.once) this.removeListener(event, listeners.fn, undefined, true);
@@ -185,14 +185,15 @@ EventEmitter.prototype.emit = function emit(event, a1, a2, a3, a4, a5) {
       case 6: return listeners.fn.call(listeners.context, a1, a2, a3, a4, a5), true;
     }
 
-    for (i = 1, args = new Array(len -1); i < len; i++) {
-      args[i - 1] = arguments[i];
+    args = [];
+    while(++i < len) {
+      args[args.length] = arguments[i];
     }
 
     listeners.fn.apply(listeners.context, args);
   } else {
     var length = listeners.length
-      , j;
+      , j = 0;
 
     for (i = 0; i < length; i++) {
       if (listeners[i].once) this.removeListener(event, listeners[i].fn, undefined, true);
@@ -203,8 +204,11 @@ EventEmitter.prototype.emit = function emit(event, a1, a2, a3, a4, a5) {
         case 3: listeners[i].fn.call(listeners[i].context, a1, a2); break;
         case 4: listeners[i].fn.call(listeners[i].context, a1, a2, a3); break;
         default:
-          if (!args) for (j = 1, args = new Array(len -1); j < len; j++) {
-            args[j - 1] = arguments[j];
+          if (!args) {
+            args = [];
+            while(++j < len) {
+              args[args.length] = arguments[j];
+            }
           }
 
           listeners[i].fn.apply(listeners[i].context, args);


### PR DESCRIPTION
original:
```
Starting benchmark emit.js

EventEmitter1 x 4,334,326 ops/sec ±0.86% (92 runs sampled)
EventEmitter2 x 8,346,704 ops/sec ±0.77% (92 runs sampled)
EventEmitter3@0.1.6 x 14,766,640 ops/sec ±0.31% (90 runs sampled)
EventEmitter3(master) x 14,888,845 ops/sec ±0.26% (92 runs sampled)
Drip x 8,332,981 ops/sec ±0.56% (94 runs sampled)
fastemitter x 6,456,471 ops/sec ±0.54% (94 runs sampled)
event-emitter x 2,892,548 ops/sec ±6.49% (85 runs sampled)
contra/emitter x 390,580 ops/sec ±0.69% (92 runs sampled)
Fastest is EventEmitter3(master)
```

new:
```
Starting benchmark emit.js

EventEmitter1 x 4,238,510 ops/sec ±0.35% (92 runs sampled)
EventEmitter2 x 8,515,373 ops/sec ±0.84% (92 runs sampled)
EventEmitter3@0.1.6 x 14,424,957 ops/sec ±0.36% (91 runs sampled)
EventEmitter3(master) x 14,818,786 ops/sec ±0.88% (93 runs sampled)
Drip x 8,500,952 ops/sec ±0.46% (86 runs sampled)
fastemitter x 6,127,489 ops/sec ±0.77% (94 runs sampled)
event-emitter x 3,252,819 ops/sec ±0.70% (91 runs sampled)
contra/emitter x 342,798 ops/sec ±0.95% (92 runs sampled)
Fastest is EventEmitter3(master)
```


