### PR TITLE
fix module export for class

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,16 @@
-export as namespace EventEmitter;
+export = EventEmitter;
 
-type ListenerFn = (...args: Array<any>) => void;
+declare namespace EventEmitter {
+  export interface ListenerFn {
+    (...args: Array<any>): void;
+  }
+}
 
 /**
  * Minimal `EventEmitter` interface that is molded against the Node.js
  * `EventEmitter` interface.
  */
-export class EventEmitter {
+declare class EventEmitter {
   static prefixed: string | boolean;
 
   /**
@@ -18,7 +22,7 @@ export class EventEmitter {
   /**
    * Return the listeners registered for a given event.
    */
-  listeners(event: string | symbol): Array<ListenerFn>;
+  listeners(event: string | symbol): Array<EventEmitter.ListenerFn>;
 
   /**
    * Return the number of listeners listening to a given event.
@@ -33,19 +37,19 @@ export class EventEmitter {
   /**
    * Add a listener for a given event.
    */
-  on(event: string | symbol, fn: ListenerFn, context?: any): this;
-  addListener(event: string | symbol, fn: ListenerFn, context?: any): this;
+  on(event: string | symbol, fn: EventEmitter.ListenerFn, context?: any): this;
+  addListener(event: string | symbol, fn: EventEmitter.ListenerFn, context?: any): this;
 
   /**
    * Add a one-time listener for a given event.
    */
-  once(event: string | symbol, fn: ListenerFn, context?: any): this;
+  once(event: string | symbol, fn: EventEmitter.ListenerFn, context?: any): this;
 
   /**
    * Remove the listeners of a given event.
    */
-  removeListener(event: string | symbol, fn?: ListenerFn, context?: any, once?: boolean): this;
-  off(event: string | symbol, fn?: ListenerFn, context?: any, once?: boolean): this;
+  removeListener(event: string | symbol, fn?: EventEmitter.ListenerFn, context?: any, once?: boolean): this;
+  off(event: string | symbol, fn?: EventEmitter.ListenerFn, context?: any, once?: boolean): this;
 
   /**
    * Remove all listeners, or those of the specified event.


### PR DESCRIPTION
As described in #104, I was having issues with the type definitions. I made these changes locally and it worked. My only concern is I don't have a great idea about backwards compatibility with older versions of the typescript compiler (I'm using 2.7.1 -- the latest stable).

see: https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-class-d-ts.html