### PR TITLE
Fixed TypeScript declaration file configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.1",
   "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
   "main": "index.js",
-  "typings": "index.d.ts",
+  "types": "index.d.ts",
   "scripts": {
     "build": "mkdir -p umd && browserify index.js -s EventEmitter3 | uglifyjs -cm -o umd/eventemitter3.min.js",
     "benchmark": "find benchmarks/run -name '*.js' -exec benchmarks/start.sh {} \\;",


### PR DESCRIPTION
According to the [TypeScript handbook](http://www.typescriptlang.org/docs/handbook/module-resolution.html), the correct name for the `index.ts.d` package key is `types` instead of "typings".

When `tsc` attempts to resolve the module, it fails:

```
C:\projects\xethya>npx tsc --traceResolution
C:\projects\xethya\node_modules\typescript\bin\tsc
======== Resolving module 'eventemitter3' from 'C:/projects/xethya/src/core/eventable.ts'. ========
Module resolution kind is not specified, using 'Classic'.
'baseUrl' option is set to 'C:/projects/xethya/', using this value to resolve non-relative module name 'eventemitter3'.
Resolving module name 'eventemitter3' relative to base url 'C:/projects/xethya/' - 'C:/projects/xethya/eventemitter3'.
File 'C:/projects/xethya/eventemitter3.ts' does not exist.
File 'C:/projects/xethya/eventemitter3.tsx' does not exist.
File 'C:/projects/xethya/eventemitter3.d.ts' does not exist.
File 'C:/projects/xethya/src/core/eventemitter3.ts' does not exist.
File 'C:/projects/xethya/src/core/eventemitter3.tsx' does not exist.
File 'C:/projects/xethya/src/core/eventemitter3.d.ts' does not exist.
File 'C:/projects/xethya/src/eventemitter3.ts' does not exist.
File 'C:/projects/xethya/src/eventemitter3.tsx' does not exist.
File 'C:/projects/xethya/src/eventemitter3.d.ts' does not exist.
File 'C:/projects/xethya/eventemitter3.ts' does not exist.
File 'C:/projects/xethya/eventemitter3.tsx' does not exist.
File 'C:/projects/xethya/eventemitter3.d.ts' does not exist.
File 'C:/projects/eventemitter3.ts' does not exist.
File 'C:/projects/eventemitter3.tsx' does not exist.
File 'C:/projects/eventemitter3.d.ts' does not exist.
File 'C:/eventemitter3.ts' does not exist.
File 'C:/eventemitter3.tsx' does not exist.
File 'C:/eventemitter3.d.ts' does not exist.
Directory 'C:/projects/xethya/src/core/node_modules' does not exist, skipping all lookups in it.
Directory 'C:/projects/xethya/src/node_modules' does not exist, skipping all lookups in it.
File 'C:/projects/xethya/node_modules/@types/eventemitter3.d.ts' does not exist.
Directory 'C:/projects/node_modules' does not exist, skipping all lookups in it.
Directory 'C:/node_modules' does not exist, skipping all lookups in it.
'baseUrl' option is set to 'C:/projects/xethya/', using this value to resolve non-relative module name 'eventemitter3'.
Resolving module name 'eventemitter3' relative to base url 'C:/projects/xethya/' - 'C:/projects/xethya/eventemitter3'.
File 'C:/projects/xethya/eventemitter3.js' does not exist.
File 'C:/projects/xethya/eventemitter3.jsx' does not exist.
File 'C:/projects/xethya/src/core/eventemitter3.js' does not exist.
File 'C:/projects/xethya/src/core/eventemitter3.jsx' does not exist.
File 'C:/projects/xethya/src/eventemitter3.js' does not exist.
File 'C:/projects/xethya/src/eventemitter3.jsx' does not exist.
File 'C:/projects/xethya/eventemitter3.js' does not exist.
File 'C:/projects/xethya/eventemitter3.jsx' does not exist.
File 'C:/projects/eventemitter3.js' does not exist.
File 'C:/projects/eventemitter3.jsx' does not exist.
File 'C:/eventemitter3.js' does not exist.
File 'C:/eventemitter3.jsx' does not exist.
======== Module name 'eventemitter3' was not resolved. ========
```