### PR TITLE
Allow user to specify argument types for events

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,61 +1,64 @@
+type EventNames<T extends string | symbol | { [K in string | symbol]: any[] }> = T extends string | symbol ? T : keyof T;
+type EventArgs<T extends string | symbol | { [K in string | symbol]: any[] }, K extends EventNames<T>> = T extends string | symbol ? any[] : K extends keyof T ? T[K] : never;
+
 /**
  * Minimal `EventEmitter` interface that is molded against the Node.js
  * `EventEmitter` interface.
  */
-declare class EventEmitter<EventTypes extends string | symbol = string | symbol> {
+declare class EventEmitter<EventTypes extends string | symbol | { [K in keyof EventTypes]: any[] } = string | symbol> {
   static prefixed: string | boolean;
 
   /**
    * Return an array listing the events for which the emitter has registered
    * listeners.
    */
-  eventNames(): Array<EventTypes>;
+  eventNames(): Array<EventNames<EventTypes>>;
 
   /**
    * Return the listeners registered for a given event.
    */
-  listeners(event: EventTypes): Array<EventEmitter.ListenerFn>;
+  listeners<T extends EventNames<EventTypes>>(event: T): Array<EventEmitter.ListenerFn<EventArgs<EventTypes, T>>>;
 
   /**
    * Return the number of listeners listening to a given event.
    */
-  listenerCount(event: EventTypes): number;
+  listenerCount(event: EventNames<EventTypes>): number;
 
   /**
    * Calls each of the listeners registered for a given event.
    */
-  emit(event: EventTypes, ...args: Array<any>): boolean;
+  emit<T extends EventNames<EventTypes>>(event: T, ...args: EventArgs<EventTypes, T>): boolean;
 
   /**
    * Add a listener for a given event.
    */
-  on(event: EventTypes, fn: EventEmitter.ListenerFn, context?: any): this;
-  addListener(event: EventTypes, fn: EventEmitter.ListenerFn, context?: any): this;
+  on<T extends EventNames<EventTypes>>(event: T, fn: EventEmitter.ListenerFn<EventArgs<EventTypes, T>>, context?: any): this;
+  addListener<T extends EventNames<EventTypes>>(event: T, fn: EventEmitter.ListenerFn<EventArgs<EventTypes, T>>, context?: any): this;
 
   /**
    * Add a one-time listener for a given event.
    */
-  once(event: EventTypes, fn: EventEmitter.ListenerFn, context?: any): this;
+  once<T extends EventNames<EventTypes>>(event: T, fn: EventEmitter.ListenerFn<EventArgs<EventTypes, T>>, context?: any): this;
 
   /**
    * Remove the listeners of a given event.
    */
-  removeListener(event: EventTypes, fn?: EventEmitter.ListenerFn, context?: any, once?: boolean): this;
-  off(event: EventTypes, fn?: EventEmitter.ListenerFn, context?: any, once?: boolean): this;
+  removeListener<T extends EventNames<EventTypes>>(event: T, fn?: EventEmitter.ListenerFn<EventArgs<EventTypes, T>>, context?: any, once?: boolean): this;
+  off<T extends EventNames<EventTypes>>(event: T, fn?: EventEmitter.ListenerFn<EventArgs<EventTypes, T>>, context?: any, once?: boolean): this;
 
   /**
    * Remove all listeners, or those of the specified event.
    */
-  removeAllListeners(event?: EventTypes): this;
+  removeAllListeners(event?: EventNames<EventTypes>): this;
 }
 
 declare namespace EventEmitter {
-  export interface ListenerFn {
-    (...args: Array<any>): void;
+  export interface ListenerFn<Args extends any[] = any[]> {
+    (...args: Args): void;
   }
 
   export interface EventEmitterStatic {
-    new<EventTypes extends string | symbol = string | symbol>(): EventEmitter<EventTypes>;
+    new<EventTypes extends string | symbol | { [K in keyof EventTypes]: any[] } = string | symbol>(): EventEmitter<EventTypes>;
   }
 
   export const EventEmitter: EventEmitterStatic;


### PR DESCRIPTION
This is purely an extension to the current typings, and should be backwards compatible for code, but requires the TypeScript 3.0+ compiler. In addition to allowing you to specify event names (as with the current typings):

```typescript
const ee = new EventEmitter<'foo' | 'bar'>();
```

you can alternatively pass an interface that maps event names to a tuple of argument types:

```typescript
interface MyEvents {
    foo: [string];
    bar: [number, number];
}

const ee = new EventEmitter<MyEvents>();

ee.emit('foo', 'hello');
ee.emit('bar', 1, 2);
```

This provides strongly typed arguments for `on`, `off`, `emit`, etc.