### PR TITLE
Note on Readme for benchmarks install

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ alternatives. To run the benchmarks run `npm run benchmark`.
 
 Tests and benchmarks are not included in the npm package. If you want to play
 with them you have to clone the GitHub repository.
+Note that you will have to run an additional `npm i` in the benchmarks foldder before `npm run benchmark`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ alternatives. To run the benchmarks run `npm run benchmark`.
 
 Tests and benchmarks are not included in the npm package. If you want to play
 with them you have to clone the GitHub repository.
-Note that you will have to run an additional `npm i` in the benchmarks folder before `npm run benchmark`.
+Note that you will have to run an additional `npm i` in the benchmarks folder
+before `npm run benchmark`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ alternatives. To run the benchmarks run `npm run benchmark`.
 
 Tests and benchmarks are not included in the npm package. If you want to play
 with them you have to clone the GitHub repository.
-Note that you will have to run an additional `npm i` in the benchmarks foldder before `npm run benchmark`.
+Note that you will have to run an additional `npm i` in the benchmarks folder before `npm run benchmark`.
 
 ## License
 


### PR DESCRIPTION
It was unclear that someone have to run `npm i` in the benchmarks folder. This small PR add a clarification in Readme.