### PR TITLE
Update type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,6 +34,7 @@ declare class EventEmitter<
   EventTypes extends
     | string
     | symbol
+    | {}
     | { [K in keyof EventTypes]: any[] | ((...args: any[]) => void) } =
     | string
     | symbol,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,44 @@
-type EventNames<T extends string | symbol | { [K in string | symbol]: any[] }> = T extends string | symbol ? T : keyof T;
-type EventArgs<T extends string | symbol | { [K in string | symbol]: any[] }, K extends EventNames<T>> = T extends string | symbol ? any[] : K extends keyof T ? T[K] : never;
+type ValidEventTypes<T = any> = string | symbol | T extends {
+  [K in keyof T]: any[] | ((...args: any[]) => void);
+}
+  ? T
+  : never;
+
+type EventNames<T extends ValidEventTypes> = T extends string | symbol
+  ? T
+  : keyof T;
+
+type Handler<
+  T extends any[] | ((...args: any[]) => R),
+  R = any
+> = T extends any[] ? (...args: T) => R : T;
+
+type EventListener<
+  T extends ValidEventTypes,
+  K extends EventNames<T>
+> = T extends string | symbol
+  ? (...args: any[]) => void
+  : K extends keyof T
+  ? Handler<T[K], void>
+  : never;
+
+type EventArgs<T extends ValidEventTypes, K extends EventNames<T>> = Parameters<
+  EventListener<T, K>
+>;
 
 /**
  * Minimal `EventEmitter` interface that is molded against the Node.js
  * `EventEmitter` interface.
  */
-declare class EventEmitter<EventTypes extends string | symbol | { [K in keyof EventTypes]: any[] } = string | symbol> {
+declare class EventEmitter<
+  EventTypes extends
+    | string
+    | symbol
+    | { [K in keyof EventTypes]: any[] | ((...args: any[]) => void) } =
+    | string
+    | symbol,
+  Context extends any = any
+> {
   static prefixed: string | boolean;
 
   /**
@@ -17,7 +50,9 @@ declare class EventEmitter<EventTypes extends string | symbol | { [K in keyof Ev
   /**
    * Return the listeners registered for a given event.
    */
-  listeners<T extends EventNames<EventTypes>>(event: T): Array<EventEmitter.ListenerFn<EventArgs<EventTypes, T>>>;
+  listeners<T extends EventNames<EventTypes>>(
+    event: T
+  ): Array<EventListener<EventTypes, T>>;
 
   /**
    * Return the number of listeners listening to a given event.
@@ -27,24 +62,49 @@ declare class EventEmitter<EventTypes extends string | symbol | { [K in keyof Ev
   /**
    * Calls each of the listeners registered for a given event.
    */
-  emit<T extends EventNames<EventTypes>>(event: T, ...args: EventArgs<EventTypes, T>): boolean;
+  emit<T extends EventNames<EventTypes>>(
+    event: T,
+    ...args: EventArgs<EventTypes, T>
+  ): boolean;
 
   /**
    * Add a listener for a given event.
    */
-  on<T extends EventNames<EventTypes>>(event: T, fn: EventEmitter.ListenerFn<EventArgs<EventTypes, T>>, context?: any): this;
-  addListener<T extends EventNames<EventTypes>>(event: T, fn: EventEmitter.ListenerFn<EventArgs<EventTypes, T>>, context?: any): this;
+  on<T extends EventNames<EventTypes>>(
+    event: T,
+    fn: EventListener<EventTypes, T>,
+    context?: Context
+  ): this;
+  addListener<T extends EventNames<EventTypes>>(
+    event: T,
+    fn: EventListener<EventTypes, T>,
+    context?: Context
+  ): this;
 
   /**
    * Add a one-time listener for a given event.
    */
-  once<T extends EventNames<EventTypes>>(event: T, fn: EventEmitter.ListenerFn<EventArgs<EventTypes, T>>, context?: any): this;
+  once<T extends EventNames<EventTypes>>(
+    event: T,
+    fn: EventListener<EventTypes, T>,
+    context?: Context
+  ): this;
 
   /**
    * Remove the listeners of a given event.
    */
-  removeListener<T extends EventNames<EventTypes>>(event: T, fn?: EventEmitter.ListenerFn<EventArgs<EventTypes, T>>, context?: any, once?: boolean): this;
-  off<T extends EventNames<EventTypes>>(event: T, fn?: EventEmitter.ListenerFn<EventArgs<EventTypes, T>>, context?: any, once?: boolean): this;
+  removeListener<T extends EventNames<EventTypes>>(
+    event: T,
+    fn?: EventListener<EventTypes, T>,
+    context?: Context,
+    once?: boolean
+  ): this;
+  off<T extends EventNames<EventTypes>>(
+    event: T,
+    fn?: EventListener<EventTypes, T>,
+    context?: Context,
+    once?: boolean
+  ): this;
 
   /**
    * Remove all listeners, or those of the specified event.
@@ -58,7 +118,7 @@ declare namespace EventEmitter {
   }
 
   export interface EventEmitterStatic {
-    new<EventTypes extends string | symbol | { [K in keyof EventTypes]: any[] } = string | symbol>(): EventEmitter<EventTypes>;
+    new <EventTypes extends ValidEventTypes>(): EventEmitter<EventTypes>;
   }
 
   export const EventEmitter: EventEmitterStatic;


### PR DESCRIPTION
This PR adds a new set of type definitions to this library, as outlined in issue https://github.com/primus/eventemitter3/issues/217. 

Right now, if the type parameter is a map of events and parameter array types, the parameters themselves don't get human-readable names. If the event map type instead supported using entire function annotations, the parameter names could be retained which makes using the library easier.

Before the changes in this PR, you could only do the following:

<img width="631" alt="Screenshot 2020-03-02 at 14 46 23" src="https://user-images.githubusercontent.com/2878342/75686718-9dc3ee00-5c94-11ea-9548-a3319c91e41b.png">

With the changes in this PR, you could do this:

<img width="630" alt="Screenshot 2020-03-02 at 14 40 12" src="https://user-images.githubusercontent.com/2878342/75686465-34dc7600-5c94-11ea-92c9-fc4702261b46.png">

Additionally, the PR adds an optional type parameter for the `context` object.
