### PR TITLE
fix: dont require index signature in event map typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -94,7 +94,7 @@ declare namespace EventEmitter {
   export type ValidEventTypes =
     | string
     | symbol
-    | { [K in string | symbol]: any[] | ((...args: any[]) => void) };
+    | { [K in string | symbol]: any[] | ((...args: any[]) => void) | undefined };
 
   export type EventNames<T extends ValidEventTypes> = T extends string | symbol
     ? T


### PR DESCRIPTION
Without this change, the following error appears when using an interface
of event listeners:

```
Type 'MyEventListeners' does not satisfy the constraint 'ValidEventTypes'.
  Type 'MyEventListeners' is not assignable to type '{ [x: string]: any[] | ((...args: any[]) => void); }'.
    Index signature is missing in type 'NodeRunnerEventListeners<Output>
```

with an interface like

```ts
interface MyEventListeners {
  log(
    content: string,
    level?: 'error' | 'warn' | 'info' | 'debug' | 'silly'
  ): void;
}
```
