### PR TITLE
Reduce type constraints

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -91,10 +91,7 @@ declare namespace EventEmitter {
     >(): EventEmitter<EventTypes, Context>;
   }
 
-  export type ValidEventTypes =
-    | string
-    | symbol
-    | { [K in string | symbol]: any[] | ((...args: any[]) => void) };
+  export type ValidEventTypes = string | symbol | object;
 
   export type EventNames<T extends ValidEventTypes> = T extends string | symbol
     ? T
@@ -108,12 +105,17 @@ declare namespace EventEmitter {
       : any[];
   };
 
+  export type Arguments<
+    T extends object,
+    K extends keyof T | string | symbol
+  > = K extends keyof T ? ArgumentMap<T>[K] : any[];
+
   export type EventListener<
     T extends ValidEventTypes,
     K extends EventNames<T>
   > = T extends string | symbol
     ? (...args: any[]) => void
-    : (...args: ArgumentMap<Exclude<T, string | symbol>>[K]) => void;
+    : (...args: Arguments<Exclude<T, string | symbol>, K>) => void;
 
   export type EventArgs<
     T extends ValidEventTypes,

--- a/index.d.ts
+++ b/index.d.ts
@@ -91,17 +91,16 @@ declare namespace EventEmitter {
     >(): EventEmitter<EventTypes, Context>;
   }
 
-  export type ValidEventTypes<T = any> = string | symbol | T extends {
-    [K in keyof T]: any[] | ((...args: any[]) => void);
-  }
-    ? T
-    : never;
+  export type ValidEventTypes =
+    | string
+    | symbol
+    | { [K in string | symbol]: any[] | ((...args: any[]) => void) };
 
   export type EventNames<T extends ValidEventTypes> = T extends string | symbol
     ? T
     : keyof T;
 
-  export type ArgumentMap<T> = {
+  export type ArgumentMap<T extends object> = {
     [K in keyof T]: T[K] extends (...args: any[]) => void
       ? Parameters<T[K]>
       : T[K] extends any[]
@@ -114,7 +113,7 @@ declare namespace EventEmitter {
     K extends EventNames<T>
   > = T extends string | symbol
     ? (...args: any[]) => void
-    : (...args: ArgumentMap<T>[K]) => void;
+    : (...args: ArgumentMap<Exclude<T, string | symbol>>[K]) => void;
 
   export type EventArgs<
     T extends ValidEventTypes,

--- a/index.d.ts
+++ b/index.d.ts
@@ -39,12 +39,22 @@ declare class EventEmitter<
    */
   on<T extends EventEmitter.EventNames<EventTypes>>(
     event: T,
-    fn: EventEmitter.EventListener<EventTypes, T> | ((...args: any[]) => void),
+    fn: EventEmitter.EventListener<EventTypes, T>,
+    context?: Context
+  ): this;
+  on<T extends EventEmitter.EventNames<EventTypes>>(
+    event: T,
+    fn: Function,
     context?: Context
   ): this;
   addListener<T extends EventEmitter.EventNames<EventTypes>>(
     event: T,
     fn: EventEmitter.EventListener<EventTypes, T>,
+    context?: Context
+  ): this;
+  addListener<T extends EventEmitter.EventNames<EventTypes>>(
+    event: T,
+    fn: Function,
     context?: Context
   ): this;
 
@@ -53,7 +63,12 @@ declare class EventEmitter<
    */
   once<T extends EventEmitter.EventNames<EventTypes>>(
     event: T,
-    fn: EventEmitter.EventListener<EventTypes, T> | ((...args: any[]) => void),
+    fn: EventEmitter.EventListener<EventTypes, T>,
+    context?: Context
+  ): this;
+  once<T extends EventEmitter.EventNames<EventTypes>>(
+    event: T,
+    fn: Function,
     context?: Context
   ): this;
 
@@ -62,13 +77,25 @@ declare class EventEmitter<
    */
   removeListener<T extends EventEmitter.EventNames<EventTypes>>(
     event: T,
-    fn?: EventEmitter.EventListener<EventTypes, T> | ((...args: any[]) => void),
+    fn?: EventEmitter.EventListener<EventTypes, T>,
+    context?: Context,
+    once?: boolean
+  ): this;
+  removeListener<T extends EventEmitter.EventNames<EventTypes>>(
+    event: T,
+    fn?: Function,
     context?: Context,
     once?: boolean
   ): this;
   off<T extends EventEmitter.EventNames<EventTypes>>(
     event: T,
-    fn?: EventEmitter.EventListener<EventTypes, T> | ((...args: any[]) => void),
+    fn?: EventEmitter.EventListener<EventTypes, T>,
+    context?: Context,
+    once?: boolean
+  ): this;
+  off<T extends EventEmitter.EventNames<EventTypes>>(
+    event: T,
+    fn?: Function,
     context?: Context,
     once?: boolean
   ): this;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,43 +1,9 @@
-type ValidEventTypes<T = any> = string | symbol | T extends {
-  [K in keyof T]: any[] | ((...args: any[]) => void);
-}
-  ? T
-  : never;
-
-type EventNames<T extends ValidEventTypes> = T extends string | symbol
-  ? T
-  : keyof T;
-
-type Handler<
-  T extends any[] | ((...args: any[]) => R),
-  R = any
-> = T extends any[] ? (...args: T) => R : T;
-
-type EventListener<
-  T extends ValidEventTypes,
-  K extends EventNames<T>
-> = T extends string | symbol
-  ? (...args: any[]) => void
-  : K extends keyof T
-  ? Handler<T[K], void>
-  : never;
-
-type EventArgs<T extends ValidEventTypes, K extends EventNames<T>> = Parameters<
-  EventListener<T, K>
->;
-
 /**
  * Minimal `EventEmitter` interface that is molded against the Node.js
  * `EventEmitter` interface.
  */
 declare class EventEmitter<
-  EventTypes extends
-    | string
-    | symbol
-    | {}
-    | { [K in keyof EventTypes]: any[] | ((...args: any[]) => void) } =
-    | string
-    | symbol,
+  EventTypes extends EventEmitter.ValidEventTypes = string | symbol,
   Context extends any = any
 > {
   static prefixed: string | boolean;
@@ -46,63 +12,63 @@ declare class EventEmitter<
    * Return an array listing the events for which the emitter has registered
    * listeners.
    */
-  eventNames(): Array<EventNames<EventTypes>>;
+  eventNames(): Array<EventEmitter.EventNames<EventTypes>>;
 
   /**
    * Return the listeners registered for a given event.
    */
-  listeners<T extends EventNames<EventTypes>>(
+  listeners<T extends EventEmitter.EventNames<EventTypes>>(
     event: T
-  ): Array<EventListener<EventTypes, T>>;
+  ): Array<EventEmitter.EventListener<EventTypes, T>>;
 
   /**
    * Return the number of listeners listening to a given event.
    */
-  listenerCount(event: EventNames<EventTypes>): number;
+  listenerCount(event: EventEmitter.EventNames<EventTypes>): number;
 
   /**
    * Calls each of the listeners registered for a given event.
    */
-  emit<T extends EventNames<EventTypes>>(
+  emit<T extends EventEmitter.EventNames<EventTypes>>(
     event: T,
-    ...args: EventArgs<EventTypes, T>
+    ...args: EventEmitter.EventArgs<EventTypes, T>
   ): boolean;
 
   /**
    * Add a listener for a given event.
    */
-  on<T extends EventNames<EventTypes>>(
+  on<T extends EventEmitter.EventNames<EventTypes>>(
     event: T,
-    fn: EventListener<EventTypes, T>,
+    fn: EventEmitter.EventListener<EventTypes, T> | ((...args: any[]) => void),
     context?: Context
   ): this;
-  addListener<T extends EventNames<EventTypes>>(
+  addListener<T extends EventEmitter.EventNames<EventTypes>>(
     event: T,
-    fn: EventListener<EventTypes, T>,
+    fn: EventEmitter.EventListener<EventTypes, T>,
     context?: Context
   ): this;
 
   /**
    * Add a one-time listener for a given event.
    */
-  once<T extends EventNames<EventTypes>>(
+  once<T extends EventEmitter.EventNames<EventTypes>>(
     event: T,
-    fn: EventListener<EventTypes, T>,
+    fn: EventEmitter.EventListener<EventTypes, T> | ((...args: any[]) => void),
     context?: Context
   ): this;
 
   /**
    * Remove the listeners of a given event.
    */
-  removeListener<T extends EventNames<EventTypes>>(
+  removeListener<T extends EventEmitter.EventNames<EventTypes>>(
     event: T,
-    fn?: EventListener<EventTypes, T>,
+    fn?: EventEmitter.EventListener<EventTypes, T> | ((...args: any[]) => void),
     context?: Context,
     once?: boolean
   ): this;
-  off<T extends EventNames<EventTypes>>(
+  off<T extends EventEmitter.EventNames<EventTypes>>(
     event: T,
-    fn?: EventListener<EventTypes, T>,
+    fn?: EventEmitter.EventListener<EventTypes, T> | ((...args: any[]) => void),
     context?: Context,
     once?: boolean
   ): this;
@@ -110,7 +76,7 @@ declare class EventEmitter<
   /**
    * Remove all listeners, or those of the specified event.
    */
-  removeAllListeners(event?: EventNames<EventTypes>): this;
+  removeAllListeners(event?: EventEmitter.EventNames<EventTypes>): this;
 }
 
 declare namespace EventEmitter {
@@ -124,6 +90,32 @@ declare namespace EventEmitter {
       Context = any
     >(): EventEmitter<EventTypes, Context>;
   }
+
+  export type ValidEventTypes<T = any> = string | symbol | T extends {
+    [K in keyof T]: any[] | ((...args: any[]) => void);
+  }
+    ? T
+    : never;
+
+  export type EventNames<T extends ValidEventTypes> = T extends string | symbol
+    ? T
+    : keyof T;
+
+  export type EventListener<
+    T extends ValidEventTypes,
+    K extends EventNames<T>
+  > = T extends string | symbol
+    ? (...args: any[]) => void
+    : T[K] extends (...args: any[]) => void
+    ? T[K]
+    : T[K] extends any[]
+    ? (...args: T[K]) => void
+    : (...args: any[]) => void;
+
+  export type EventArgs<
+    T extends ValidEventTypes,
+    K extends EventNames<T>
+  > = Parameters<EventListener<T, K>>;
 
   export const EventEmitter: EventEmitterStatic;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,19 +42,9 @@ declare class EventEmitter<
     fn: EventEmitter.EventListener<EventTypes, T>,
     context?: Context
   ): this;
-  on<T extends EventEmitter.EventNames<EventTypes>>(
-    event: T,
-    fn: Function,
-    context?: Context
-  ): this;
   addListener<T extends EventEmitter.EventNames<EventTypes>>(
     event: T,
     fn: EventEmitter.EventListener<EventTypes, T>,
-    context?: Context
-  ): this;
-  addListener<T extends EventEmitter.EventNames<EventTypes>>(
-    event: T,
-    fn: Function,
     context?: Context
   ): this;
 
@@ -64,11 +54,6 @@ declare class EventEmitter<
   once<T extends EventEmitter.EventNames<EventTypes>>(
     event: T,
     fn: EventEmitter.EventListener<EventTypes, T>,
-    context?: Context
-  ): this;
-  once<T extends EventEmitter.EventNames<EventTypes>>(
-    event: T,
-    fn: Function,
     context?: Context
   ): this;
 
@@ -81,21 +66,9 @@ declare class EventEmitter<
     context?: Context,
     once?: boolean
   ): this;
-  removeListener<T extends EventEmitter.EventNames<EventTypes>>(
-    event: T,
-    fn?: Function,
-    context?: Context,
-    once?: boolean
-  ): this;
   off<T extends EventEmitter.EventNames<EventTypes>>(
     event: T,
     fn?: EventEmitter.EventListener<EventTypes, T>,
-    context?: Context,
-    once?: boolean
-  ): this;
-  off<T extends EventEmitter.EventNames<EventTypes>>(
-    event: T,
-    fn?: Function,
     context?: Context,
     once?: boolean
   ): this;
@@ -128,16 +101,20 @@ declare namespace EventEmitter {
     ? T
     : keyof T;
 
+  export type ArgumentMap<T> = {
+    [K in keyof T]: T[K] extends (...args: any[]) => void
+      ? Parameters<T[K]>
+      : T[K] extends any[]
+      ? T[K]
+      : any[];
+  };
+
   export type EventListener<
     T extends ValidEventTypes,
     K extends EventNames<T>
   > = T extends string | symbol
     ? (...args: any[]) => void
-    : T[K] extends (...args: any[]) => void
-    ? T[K]
-    : T[K] extends any[]
-    ? (...args: T[K]) => void
-    : (...args: any[]) => void;
+    : (...args: ArgumentMap<T>[K]) => void;
 
   export type EventArgs<
     T extends ValidEventTypes,

--- a/index.d.ts
+++ b/index.d.ts
@@ -119,7 +119,10 @@ declare namespace EventEmitter {
   }
 
   export interface EventEmitterStatic {
-    new <EventTypes extends ValidEventTypes>(): EventEmitter<EventTypes>;
+    new <
+      EventTypes extends ValidEventTypes = string | symbol,
+      Context = any
+    >(): EventEmitter<EventTypes, Context>;
   }
 
   export const EventEmitter: EventEmitterStatic;


### PR DESCRIPTION
This PR fixes the same issue that #231 was addressing. The PR didn't properly fix the issue.

The underlying problem was that TypeScript now requires an index signature for object types as currently used in the type constraint for `ValidEventMaps`.

The PR relaxes the type constraint to allow arbitrary object types. The event emitter will recognise all keys `K` of the object type `T` as event names.

The existing behaviour does not change: If the type `T[K]` is an array type, it is used as the type of the event args. If it is a function type, the parameter type of the function becomes the type of the event args.

The new behaviour is that for keys where `T[K]` is neither a function nor an array type, the argument type for the event `K` now becomes `any[]`.

This fixes the bug and the relaxation should offer an acceptable compromise.