### PR TITLE
fix: refine the types more, to improve type extends behaviour

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -91,6 +91,15 @@ declare namespace EventEmitter {
     >(): EventEmitter<EventTypes, Context>;
   }
 
+  /**
+   * `object` should be in either of the following forms:
+   * ```
+   * interface EventTypes {
+   *   'event-with-parameters': any[]
+   *   'event-with-example-handler': (...args: any[]) => void
+   * }
+   * ```
+   */
   export type ValidEventTypes = string | symbol | object;
 
   export type EventNames<T extends ValidEventTypes> = T extends string | symbol
@@ -105,17 +114,14 @@ declare namespace EventEmitter {
       : any[];
   };
 
-  export type Arguments<
-    T extends object,
-    K extends keyof T | string | symbol
-  > = K extends keyof T ? ArgumentMap<T>[K] : any[];
-
   export type EventListener<
     T extends ValidEventTypes,
     K extends EventNames<T>
   > = T extends string | symbol
     ? (...args: any[]) => void
-    : (...args: Arguments<Exclude<T, string | symbol>, K>) => void;
+    : (
+        ...args: ArgumentMap<Exclude<T, string | symbol>>[Extract<K, keyof T>]
+      ) => void;
 
   export type EventArgs<
     T extends ValidEventTypes,


### PR DESCRIPTION
See also: #233 (i pulled the doc comment from here), #232, #231

The old types prevented

```ts
interface MyEventListeners {
  print(message: string): void
}

class MyEmitter extends EventEmitter<MyEventListeners> {
  emit<Event extends keyof MyEventListeners>(
    event: keyof MyEventListeners
    ...args: Parameters<MyEventListeners[Event]>
  ) {
    // customizations
    return super.emit(event, ...args);
  }
}
```

from working properly, as typescript borked where it fails to match
the arguments types with impossible-to-reach types.

The smallest change to achieve this fix is to change the `any[]` in `Arguments<...>` to `never`.

to understand this change, understand that the reference to the `Arguments` type will _never_ reach the `any[]` case from within the `EventListener` type mapping, since `K` already must be a `keyof T` once we're in the alternate(else, after the :) branch of `T extends string | symbol`, since `EventNames` in this case will be _specifically_ `keyof T`.

Typescript just isn't smart enough to them since this situation runs in parallel (not actually parallelism, just like, conceptually) in the type checker, the invariant i've attempted to describe is coincidental; the causation doesn't flow from one to the other or vice versa.

And the `ArgumentMap` type will already handle the `any[]` type for when the value in the object isn't a function or array.

Hope you can understand this explanation well enough to merge this change! I've done my best, i could do better with a whiteboard.

Also, i don't like having the type name `Arguments` because it's too close (IMO) to the builtin [`IArguments`](https://github.com/microsoft/TypeScript/blob/9ff24b6/lib/lib.es5.d.ts#L388), so I felt it worthwhile to just remove that type, keep it smaller.