### PR TITLE
typescript export two way

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -131,4 +131,5 @@ declare namespace EventEmitter {
   export const EventEmitter: EventEmitterStatic;
 }
 
-export = EventEmitter;
+export const EventEmitter;
+export default EventEmitter;


### PR DESCRIPTION
keep `EventEmitter` type in both way of importing it

ether:
```js
import { EventEmitter } from 'eventemitter3'
```
or:
```js
import EventEmitter from 'eventemitter3'
```

