### PR TITLE
Added Emittery to benchmarks

### DIFF
--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -17,7 +17,7 @@
     "eventemitter2": "latest",
     "eventemitter3": "0.1.6",
     "fastemitter": "latest",
-    "emittery": "latest"
+    "emittery": "latest",
     "events": "latest"
   }
 }

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -18,5 +18,6 @@
     "eventemitter2": "latest",
     "eventemitter3": "0.1.6",
     "fastemitter": "latest"
+    "emittery": "latest"
   }
 }

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -17,7 +17,6 @@
     "eventemitter2": "latest",
     "eventemitter3": "0.1.6",
     "fastemitter": "latest",
-    "emittery": "latest",
-    "events": "latest"
+    "emittery": "latest"
   }
 }

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -18,5 +18,6 @@
     "eventemitter3": "0.1.6",
     "fastemitter": "latest",
     "emittery": "latest"
+    "events": "latest"
   }
 }

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -13,7 +13,6 @@
     "benchmark": "2.1.x",
     "contra": "latest",
     "drip": "latest",
-    "emittery": "^1.0.1",
     "event-emitter": "latest",
     "eventemitter2": "latest",
     "eventemitter3": "0.1.6",

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -17,7 +17,7 @@
     "event-emitter": "latest",
     "eventemitter2": "latest",
     "eventemitter3": "0.1.6",
-    "fastemitter": "latest"
+    "fastemitter": "latest",
     "emittery": "latest"
   }
 }

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -13,6 +13,7 @@
     "benchmark": "2.1.x",
     "contra": "latest",
     "drip": "latest",
+    "emittery": "^1.0.1",
     "event-emitter": "latest",
     "eventemitter2": "latest",
     "eventemitter3": "0.1.6",

--- a/benchmarks/run/add-remove.js
+++ b/benchmarks/run/add-remove.js
@@ -4,7 +4,7 @@
   var benchmark = require('benchmark');
 
   var EventEmitter2 = require('eventemitter2').EventEmitter2
-    , EventEmitter1 = require('events').EventEmitter
+    , EventEmitter1 = require('node:events').EventEmitter
     , EventEmitter3 = require('eventemitter3')
     , Drip = require('drip').EventEmitter
     , CE = require('contra/emitter')

--- a/benchmarks/run/add-remove.js
+++ b/benchmarks/run/add-remove.js
@@ -1,62 +1,65 @@
 'use strict';
 
-var benchmark = require('benchmark');
+(async () => {
+  var benchmark = require('benchmark');
 
-var EventEmitter2 = require('eventemitter2').EventEmitter2
-  , EventEmitter1 = require('events').EventEmitter
-  , EventEmitter3 = require('eventemitter3')
-  , Drip = require('drip').EventEmitter
-  , CE = require('contra/emitter')
-  , EE = require('event-emitter')
-  , FE = require('fastemitter')
-  , ET = require('emittery')
-  , Master = require('../../');
+  var EventEmitter2 = require('eventemitter2').EventEmitter2
+    , EventEmitter1 = require('events').EventEmitter
+    , EventEmitter3 = require('eventemitter3')
+    , Drip = require('drip').EventEmitter
+    , CE = require('contra/emitter')
+    , EE = require('event-emitter')
+    , FE = require('fastemitter')
+    , ET = (await import('emittery')).default
+    , Master = require('../../');
 
-function handle() {
-  if (arguments.length > 100) console.log('damn');
-}
+  function handle() {
+    if (arguments.length > 100) console.log('damn');
+  }
 
-var ee1 = new EventEmitter1()
-  , ee2 = new EventEmitter2()
-  , ee3 = new EventEmitter3()
-  , master = new Master()
-  , drip = new Drip()
-  , fe = new FE()
-  , ce = CE()
-  , ee = EE()
-  , et = new ET();
+  var ee1 = new EventEmitter1()
+    , ee2 = new EventEmitter2()
+    , ee3 = new EventEmitter3()
+    , master = new Master()
+    , drip = new Drip()
+    , fe = new FE()
+    , ce = CE()
+    , ee = EE()
+    , et = new ET();
 
-(
-  new benchmark.Suite()
-).add('EventEmitter1', function() {
-  ee1.on('foo', handle);
-  ee1.removeListener('foo', handle);
-}).add('EventEmitter2', function() {
-  ee2.on('foo', handle);
-  ee2.removeListener('foo', handle);
-}).add('EventEmitter3@0.1.6', function() {
-  ee3.on('foo', handle);
-  ee3.removeListener('foo', handle);
-}).add('EventEmitter3(master)', function() {
-  master.on('foo', handle);
-  master.removeListener('foo', handle);
-}).add('Drip', function() {
-  drip.on('foo', handle);
-  drip.removeListener('foo', handle);
-}).add('fastemitter', function() {
-  fe.on('foo', handle);
-  fe.removeListener('foo', handle);
-}).add('event-emitter', function() {
-  ee.on('foo', handle);
-  ee.off('foo', handle);
-}).add('contra/emitter', function() {
-  ce.on('foo', handle);
-  ce.off('foo', handle);
-}).add('Emittery', function () {
-  et.on('foo', handler);
-  et.off('foo', handle);
-}).on('cycle', function cycle(e) {
-  console.log(e.target.toString());
-}).on('complete', function completed() {
-  console.log('Fastest is %s', this.filter('fastest').map('name'));
-}).run({ async: true });
+  (
+    new benchmark.Suite()
+  ).add('EventEmitter1', function() {
+    ee1.on('foo', handle);
+    ee1.removeListener('foo', handle);
+  }).add('EventEmitter2', function() {
+    ee2.on('foo', handle);
+    ee2.removeListener('foo', handle);
+  }).add('EventEmitter3@0.1.6', function() {
+    ee3.on('foo', handle);
+    ee3.removeListener('foo', handle);
+  }).add('EventEmitter3(master)', function() {
+    master.on('foo', handle);
+    master.removeListener('foo', handle);
+  }).add('Drip', function() {
+    drip.on('foo', handle);
+    drip.removeListener('foo', handle);
+  }).add('fastemitter', function() {
+    fe.on('foo', handle);
+    fe.removeListener('foo', handle);
+  }).add('event-emitter', function() {
+    ee.on('foo', handle);
+    ee.off('foo', handle);
+  }).add('contra/emitter', function() {
+    ce.on('foo', handle);
+    ce.off('foo', handle);
+  }).add('Emittery', function () {
+    et.on('foo', handler);
+    et.off('foo', handle);
+  }).on('cycle', function cycle(e) {
+    console.log(e.target.toString());
+  }).on('complete', function completed() {
+    console.log('Fastest is %s', this.filter('fastest').map('name'));
+  }).run({ async: true });
+
+})();

--- a/benchmarks/run/add-remove.js
+++ b/benchmarks/run/add-remove.js
@@ -9,6 +9,7 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
   , CE = require('contra/emitter')
   , EE = require('event-emitter')
   , FE = require('fastemitter')
+  , ET = require('emittery')
   , Master = require('../../');
 
 function handle() {
@@ -22,7 +23,8 @@ var ee1 = new EventEmitter1()
   , drip = new Drip()
   , fe = new FE()
   , ce = CE()
-  , ee = EE();
+  , ee = EE()
+  , et = new ET();
 
 (
   new benchmark.Suite()
@@ -50,6 +52,9 @@ var ee1 = new EventEmitter1()
 }).add('contra/emitter', function() {
   ce.on('foo', handle);
   ce.off('foo', handle);
+}).add('Emittery', function () {
+  et.on('foo', handler);
+  et.off('foo', handle);
 }).on('cycle', function cycle(e) {
   console.log(e.target.toString());
 }).on('complete', function completed() {

--- a/benchmarks/run/add-remove.js
+++ b/benchmarks/run/add-remove.js
@@ -54,7 +54,7 @@
     ce.on('foo', handle);
     ce.off('foo', handle);
   }).add('Emittery', function () {
-    et.on('foo', handler);
+    et.on('foo', handle);
     et.off('foo', handle);
   }).on('cycle', function cycle(e) {
     console.log(e.target.toString());

--- a/benchmarks/run/context.js
+++ b/benchmarks/run/context.js
@@ -1,92 +1,95 @@
 'use strict';
 
-var benchmark = require('benchmark');
+(async () => {
+  var benchmark = require('benchmark');
 
-var EventEmitter2 = require('eventemitter2').EventEmitter2
-  , EventEmitter1 = require('events').EventEmitter
-  , EventEmitter3 = require('eventemitter3')
-  , Drip = require('drip').EventEmitter
-  , CE = require('contra/emitter')
-  , EE = require('event-emitter')
-  , FE = require('fastemitter')
-  , ET = require('emittery')
-  , Master = require('../../');
+  var EventEmitter2 = require('eventemitter2').EventEmitter2
+    , EventEmitter1 = require('events').EventEmitter
+    , EventEmitter3 = require('eventemitter3')
+    , Drip = require('drip').EventEmitter
+    , CE = require('contra/emitter')
+    , EE = require('event-emitter')
+    , FE = require('fastemitter')
+    , ET = (await import('emittery')).default
+    , Master = require('../../');
 
-var ctx = { foo: 'bar' };
+  var ctx = { foo: 'bar' };
 
-function handle() {
-  if (arguments.length > 100) console.log('damn');
-}
+  function handle() {
+    if (arguments.length > 100) console.log('damn');
+  }
 
-var ee1 = new EventEmitter1()
-  , ee2 = new EventEmitter2()
-  , ee3 = new EventEmitter3()
-  , master = new Master()
-  , drip = new Drip()
-  , fe = new FE()
-  , ce = CE()
-  , ee = EE()
-  , et = new ET();
+  var ee1 = new EventEmitter1()
+    , ee2 = new EventEmitter2()
+    , ee3 = new EventEmitter3()
+    , master = new Master()
+    , drip = new Drip()
+    , fe = new FE()
+    , ce = CE()
+    , ee = EE()
+    , et = new ET();
 
-ee3.on('foo', handle, ctx);
-ee2.on('foo', handle.bind(ctx));
-ee1.on('foo', handle.bind(ctx));
-drip.on('foo', handle.bind(ctx));
-master.on('foo', handle, ctx);
-ee.on('foo', handle.bind(ctx));
-fe.on('foo', handle.bind(ctx));
-ce.on('foo', handle.bind(ctx));
-et.on('foo', handle.bind(ctx));
+  ee3.on('foo', handle, ctx);
+  ee2.on('foo', handle.bind(ctx));
+  ee1.on('foo', handle.bind(ctx));
+  drip.on('foo', handle.bind(ctx));
+  master.on('foo', handle, ctx);
+  ee.on('foo', handle.bind(ctx));
+  fe.on('foo', handle.bind(ctx));
+  ce.on('foo', handle.bind(ctx));
+  et.on('foo', handle.bind(ctx));
 
-(
-  new benchmark.Suite()
-).add('EventEmitter1', function() {
-  ee1.emit('foo');
-  ee1.emit('foo', 'bar');
-  ee1.emit('foo', 'bar', 'baz');
-  ee1.emit('foo', 'bar', 'baz', 'boom');
-}).add('EventEmitter2', function() {
-  ee2.emit('foo');
-  ee2.emit('foo', 'bar');
-  ee2.emit('foo', 'bar', 'baz');
-  ee2.emit('foo', 'bar', 'baz', 'boom');
-}).add('EventEmitter3@0.1.6', function() {
-  ee3.emit('foo');
-  ee3.emit('foo', 'bar');
-  ee3.emit('foo', 'bar', 'baz');
-  ee3.emit('foo', 'bar', 'baz', 'boom');
-}).add('EventEmitter3(master)', function() {
-  master.emit('foo');
-  master.emit('foo', 'bar');
-  master.emit('foo', 'bar', 'baz');
-  master.emit('foo', 'bar', 'baz', 'boom');
-}).add('Drip', function() {
-  drip.emit('foo');
-  drip.emit('foo', 'bar');
-  drip.emit('foo', 'bar', 'baz');
-  drip.emit('foo', 'bar', 'baz', 'boom');
-}).add('fastemitter', function() {
-  fe.emit('foo');
-  fe.emit('foo', 'bar');
-  fe.emit('foo', 'bar', 'baz');
-  fe.emit('foo', 'bar', 'baz', 'boom');
-}).add('event-emitter', function() {
-  ee.emit('foo');
-  ee.emit('foo', 'bar');
-  ee.emit('foo', 'bar', 'baz');
-  ee.emit('foo', 'bar', 'baz', 'boom');
-}).add('contra/emitter', function() {
-  ce.emit('foo');
-  ce.emit('foo', 'bar');
-  ce.emit('foo', 'bar', 'baz');
-  ce.emit('foo', 'bar', 'baz', 'boom');
-}).add('Emittery', function() {
-  et.emit('foo');
-  et.emit('foo', 'bar');
-  et.emit('foo', 'bar', 'baz');
-  et.emit('foo', 'bar', 'baz', 'boom');
-}).on('cycle', function cycle(e) {
-  console.log(e.target.toString());
-}).on('complete', function completed() {
-  console.log('Fastest is %s', this.filter('fastest').map('name'));
-}).run({ async: true });
+  (
+    new benchmark.Suite()
+  ).add('EventEmitter1', function() {
+    ee1.emit('foo');
+    ee1.emit('foo', 'bar');
+    ee1.emit('foo', 'bar', 'baz');
+    ee1.emit('foo', 'bar', 'baz', 'boom');
+  }).add('EventEmitter2', function() {
+    ee2.emit('foo');
+    ee2.emit('foo', 'bar');
+    ee2.emit('foo', 'bar', 'baz');
+    ee2.emit('foo', 'bar', 'baz', 'boom');
+  }).add('EventEmitter3@0.1.6', function() {
+    ee3.emit('foo');
+    ee3.emit('foo', 'bar');
+    ee3.emit('foo', 'bar', 'baz');
+    ee3.emit('foo', 'bar', 'baz', 'boom');
+  }).add('EventEmitter3(master)', function() {
+    master.emit('foo');
+    master.emit('foo', 'bar');
+    master.emit('foo', 'bar', 'baz');
+    master.emit('foo', 'bar', 'baz', 'boom');
+  }).add('Drip', function() {
+    drip.emit('foo');
+    drip.emit('foo', 'bar');
+    drip.emit('foo', 'bar', 'baz');
+    drip.emit('foo', 'bar', 'baz', 'boom');
+  }).add('fastemitter', function() {
+    fe.emit('foo');
+    fe.emit('foo', 'bar');
+    fe.emit('foo', 'bar', 'baz');
+    fe.emit('foo', 'bar', 'baz', 'boom');
+  }).add('event-emitter', function() {
+    ee.emit('foo');
+    ee.emit('foo', 'bar');
+    ee.emit('foo', 'bar', 'baz');
+    ee.emit('foo', 'bar', 'baz', 'boom');
+  }).add('contra/emitter', function() {
+    ce.emit('foo');
+    ce.emit('foo', 'bar');
+    ce.emit('foo', 'bar', 'baz');
+    ce.emit('foo', 'bar', 'baz', 'boom');
+  }).add('Emittery', function() {
+    et.emit('foo');
+    et.emit('foo', 'bar');
+    et.emit('foo', 'bar', 'baz');
+    et.emit('foo', 'bar', 'baz', 'boom');
+  }).on('cycle', function cycle(e) {
+    console.log(e.target.toString());
+  }).on('complete', function completed() {
+    console.log('Fastest is %s', this.filter('fastest').map('name'));
+  }).run({ async: true });
+
+})();

--- a/benchmarks/run/context.js
+++ b/benchmarks/run/context.js
@@ -4,7 +4,7 @@
   var benchmark = require('benchmark');
 
   var EventEmitter2 = require('eventemitter2').EventEmitter2
-    , EventEmitter1 = require('events').EventEmitter
+    , EventEmitter1 = require('node:events').EventEmitter
     , EventEmitter3 = require('eventemitter3')
     , Drip = require('drip').EventEmitter
     , CE = require('contra/emitter')

--- a/benchmarks/run/context.js
+++ b/benchmarks/run/context.js
@@ -9,6 +9,7 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
   , CE = require('contra/emitter')
   , EE = require('event-emitter')
   , FE = require('fastemitter')
+  , ET = require('emittery')
   , Master = require('../../');
 
 var ctx = { foo: 'bar' };
@@ -24,7 +25,8 @@ var ee1 = new EventEmitter1()
   , drip = new Drip()
   , fe = new FE()
   , ce = CE()
-  , ee = EE();
+  , ee = EE()
+  , et = new ET();
 
 ee3.on('foo', handle, ctx);
 ee2.on('foo', handle.bind(ctx));
@@ -34,6 +36,7 @@ master.on('foo', handle, ctx);
 ee.on('foo', handle.bind(ctx));
 fe.on('foo', handle.bind(ctx));
 ce.on('foo', handle.bind(ctx));
+et.on('foo', handle.bind(ctx));
 
 (
   new benchmark.Suite()
@@ -77,6 +80,11 @@ ce.on('foo', handle.bind(ctx));
   ce.emit('foo', 'bar');
   ce.emit('foo', 'bar', 'baz');
   ce.emit('foo', 'bar', 'baz', 'boom');
+}).add('Emittery', function() {
+  et.emit('foo');
+  et.emit('foo', 'bar');
+  et.emit('foo', 'bar', 'baz');
+  et.emit('foo', 'bar', 'baz', 'boom');
 }).on('cycle', function cycle(e) {
   console.log(e.target.toString());
 }).on('complete', function completed() {

--- a/benchmarks/run/emit-multiple-listeners.js
+++ b/benchmarks/run/emit-multiple-listeners.js
@@ -39,7 +39,7 @@
     , ee = EE()
     , et = new ET();
 
-  et.on('foo', foo).on('foo', bar).on('foo', baz);
+  et.on('foo', foo);et.on('foo', bar);et.on('foo', baz);
   ce.on('foo', foo).on('foo', bar).on('foo', baz);
   ee.on('foo', foo).on('foo', bar).on('foo', baz);
   fe.on('foo', foo).on('foo', bar).on('foo', baz);

--- a/benchmarks/run/emit-multiple-listeners.js
+++ b/benchmarks/run/emit-multiple-listeners.js
@@ -1,101 +1,104 @@
 'use strict';
 
-var benchmark = require('benchmark');
+(async () => {
+  var benchmark = require('benchmark');
 
-var EventEmitter2 = require('eventemitter2').EventEmitter2
-  , EventEmitter1 = require('events').EventEmitter
-  , EventEmitter3 = require('eventemitter3')
-  , CE = require('contra/emitter')
-  , EE = require('event-emitter')
-  , FE = require('fastemitter')
-  , ET = require('emittery')
-  , Master = require('../../');
+  var EventEmitter2 = require('eventemitter2').EventEmitter2
+    , EventEmitter1 = require('events').EventEmitter
+    , EventEmitter3 = require('eventemitter3')
+    , CE = require('contra/emitter')
+    , EE = require('event-emitter')
+    , FE = require('fastemitter')
+    , ET = (await import('emittery')).default
+    , Master = require('../../');
 
-function foo() {
-  if (arguments.length > 100) console.log('damn');
+  function foo() {
+    if (arguments.length > 100) console.log('damn');
 
-  return 1;
-}
+    return 1;
+  }
 
-function bar() {
-  if (arguments.length > 100) console.log('damn');
+  function bar() {
+    if (arguments.length > 100) console.log('damn');
 
-  return false;
-}
+    return false;
+  }
 
-function baz() {
-  if (arguments.length > 100) console.log('damn');
+  function baz() {
+    if (arguments.length > 100) console.log('damn');
 
-  return true;
-}
+    return true;
+  }
 
-var ee1 = new EventEmitter1()
-  , ee2 = new EventEmitter2()
-  , ee3 = new EventEmitter3()
-  , master = new Master()
-  , fe = new FE()
-  , ce = CE()
-  , ee = EE()
-  , et = new ET();
+  var ee1 = new EventEmitter1()
+    , ee2 = new EventEmitter2()
+    , ee3 = new EventEmitter3()
+    , master = new Master()
+    , fe = new FE()
+    , ce = CE()
+    , ee = EE()
+    , et = new ET();
 
-et.on('foo', foo).on('foo', bar).on('foo', baz);
-ce.on('foo', foo).on('foo', bar).on('foo', baz);
-ee.on('foo', foo).on('foo', bar).on('foo', baz);
-fe.on('foo', foo).on('foo', bar).on('foo', baz);
-ee3.on('foo', foo).on('foo', bar).on('foo', baz);
-ee2.on('foo', foo).on('foo', bar).on('foo', baz);
-ee1.on('foo', foo).on('foo', bar).on('foo', baz);
-master.on('foo', foo).on('foo', bar).on('foo', baz);
+  et.on('foo', foo).on('foo', bar).on('foo', baz);
+  ce.on('foo', foo).on('foo', bar).on('foo', baz);
+  ee.on('foo', foo).on('foo', bar).on('foo', baz);
+  fe.on('foo', foo).on('foo', bar).on('foo', baz);
+  ee3.on('foo', foo).on('foo', bar).on('foo', baz);
+  ee2.on('foo', foo).on('foo', bar).on('foo', baz);
+  ee1.on('foo', foo).on('foo', bar).on('foo', baz);
+  master.on('foo', foo).on('foo', bar).on('foo', baz);
 
-//
-// Drip is omitted as it throws an error.
-// Ref: https://github.com/qualiancy/drip/pull/4
-//
+  //
+  // Drip is omitted as it throws an error.
+  // Ref: https://github.com/qualiancy/drip/pull/4
+  //
 
-(
-  new benchmark.Suite()
-).add('EventEmitter1', function() {
-  ee1.emit('foo');
-  ee1.emit('foo', 'bar');
-  ee1.emit('foo', 'bar', 'baz');
-  ee1.emit('foo', 'bar', 'baz', 'boom');
-}).add('EventEmitter2', function() {
-  ee2.emit('foo');
-  ee2.emit('foo', 'bar');
-  ee2.emit('foo', 'bar', 'baz');
-  ee2.emit('foo', 'bar', 'baz', 'boom');
-}).add('EventEmitter3@0.1.6', function() {
-  ee3.emit('foo');
-  ee3.emit('foo', 'bar');
-  ee3.emit('foo', 'bar', 'baz');
-  ee3.emit('foo', 'bar', 'baz', 'boom');
-}).add('EventEmitter3(master)', function() {
-  master.emit('foo');
-  master.emit('foo', 'bar');
-  master.emit('foo', 'bar', 'baz');
-  master.emit('foo', 'bar', 'baz', 'boom');
-}).add('fastemitter', function() {
-  fe.emit('foo');
-  fe.emit('foo', 'bar');
-  fe.emit('foo', 'bar', 'baz');
-  fe.emit('foo', 'bar', 'baz', 'boom');
-}).add('event-emitter', function() {
-  ee.emit('foo');
-  ee.emit('foo', 'bar');
-  ee.emit('foo', 'bar', 'baz');
-  ee.emit('foo', 'bar', 'baz', 'boom');
-}).add('contra/emitter', function() {
-  ce.emit('foo');
-  ce.emit('foo', 'bar');
-  ce.emit('foo', 'bar', 'baz');
-  ce.emit('foo', 'bar', 'baz', 'boom');
-}).add('Emittery', function() {
-  et.emit('foo');
-  et.emit('foo', 'bar');
-  et.emit('foo', 'bar', 'baz');
-  et.emit('foo', 'bar', 'baz', 'boom');
-}).on('cycle', function cycle(e) {
-  console.log(e.target.toString());
-}).on('complete', function completed() {
-  console.log('Fastest is %s', this.filter('fastest').map('name'));
-}).run({ async: true });
+  (
+    new benchmark.Suite()
+  ).add('EventEmitter1', function() {
+    ee1.emit('foo');
+    ee1.emit('foo', 'bar');
+    ee1.emit('foo', 'bar', 'baz');
+    ee1.emit('foo', 'bar', 'baz', 'boom');
+  }).add('EventEmitter2', function() {
+    ee2.emit('foo');
+    ee2.emit('foo', 'bar');
+    ee2.emit('foo', 'bar', 'baz');
+    ee2.emit('foo', 'bar', 'baz', 'boom');
+  }).add('EventEmitter3@0.1.6', function() {
+    ee3.emit('foo');
+    ee3.emit('foo', 'bar');
+    ee3.emit('foo', 'bar', 'baz');
+    ee3.emit('foo', 'bar', 'baz', 'boom');
+  }).add('EventEmitter3(master)', function() {
+    master.emit('foo');
+    master.emit('foo', 'bar');
+    master.emit('foo', 'bar', 'baz');
+    master.emit('foo', 'bar', 'baz', 'boom');
+  }).add('fastemitter', function() {
+    fe.emit('foo');
+    fe.emit('foo', 'bar');
+    fe.emit('foo', 'bar', 'baz');
+    fe.emit('foo', 'bar', 'baz', 'boom');
+  }).add('event-emitter', function() {
+    ee.emit('foo');
+    ee.emit('foo', 'bar');
+    ee.emit('foo', 'bar', 'baz');
+    ee.emit('foo', 'bar', 'baz', 'boom');
+  }).add('contra/emitter', function() {
+    ce.emit('foo');
+    ce.emit('foo', 'bar');
+    ce.emit('foo', 'bar', 'baz');
+    ce.emit('foo', 'bar', 'baz', 'boom');
+  }).add('Emittery', function() {
+    et.emit('foo');
+    et.emit('foo', 'bar');
+    et.emit('foo', 'bar', 'baz');
+    et.emit('foo', 'bar', 'baz', 'boom');
+  }).on('cycle', function cycle(e) {
+    console.log(e.target.toString());
+  }).on('complete', function completed() {
+    console.log('Fastest is %s', this.filter('fastest').map('name'));
+  }).run({ async: true });
+
+})();

--- a/benchmarks/run/emit-multiple-listeners.js
+++ b/benchmarks/run/emit-multiple-listeners.js
@@ -4,7 +4,7 @@
   var benchmark = require('benchmark');
 
   var EventEmitter2 = require('eventemitter2').EventEmitter2
-    , EventEmitter1 = require('events').EventEmitter
+    , EventEmitter1 = require('node:events').EventEmitter
     , EventEmitter3 = require('eventemitter3')
     , CE = require('contra/emitter')
     , EE = require('event-emitter')

--- a/benchmarks/run/emit-multiple-listeners.js
+++ b/benchmarks/run/emit-multiple-listeners.js
@@ -8,6 +8,7 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
   , CE = require('contra/emitter')
   , EE = require('event-emitter')
   , FE = require('fastemitter')
+  , ET = require('emittery')
   , Master = require('../../');
 
 function foo() {
@@ -34,8 +35,10 @@ var ee1 = new EventEmitter1()
   , master = new Master()
   , fe = new FE()
   , ce = CE()
-  , ee = EE();
+  , ee = EE()
+  , et = new ET();
 
+et.on('foo', foo).on('foo', bar).on('foo', baz);
 ce.on('foo', foo).on('foo', bar).on('foo', baz);
 ee.on('foo', foo).on('foo', bar).on('foo', baz);
 fe.on('foo', foo).on('foo', bar).on('foo', baz);
@@ -86,6 +89,11 @@ master.on('foo', foo).on('foo', bar).on('foo', baz);
   ce.emit('foo', 'bar');
   ce.emit('foo', 'bar', 'baz');
   ce.emit('foo', 'bar', 'baz', 'boom');
+}).add('Emittery', function() {
+  et.emit('foo');
+  et.emit('foo', 'bar');
+  et.emit('foo', 'bar', 'baz');
+  et.emit('foo', 'bar', 'baz', 'boom');
 }).on('cycle', function cycle(e) {
   console.log(e.target.toString());
 }).on('complete', function completed() {

--- a/benchmarks/run/emit.js
+++ b/benchmarks/run/emit.js
@@ -1,90 +1,93 @@
 'use strict';
 
-var benchmark = require('benchmark');
+(async () => {
+  var benchmark = require('benchmark');
 
-var EventEmitter2 = require('eventemitter2').EventEmitter2
-  , EventEmitter1 = require('events').EventEmitter
-  , EventEmitter3 = require('eventemitter3')
-  , Drip = require('drip').EventEmitter
-  , CE = require('contra/emitter')
-  , EE = require('event-emitter')
-  , FE = require('fastemitter')
-  , ET = require('emittery')
-  , Master = require('../../');
+  var EventEmitter2 = require('eventemitter2').EventEmitter2
+    , EventEmitter1 = require('events').EventEmitter
+    , EventEmitter3 = require('eventemitter3')
+    , Drip = require('drip').EventEmitter
+    , CE = require('contra/emitter')
+    , EE = require('event-emitter')
+    , FE = require('fastemitter')
+    , ET = (await import('emittery')).default
+    , Master = require('../../');
 
-function handle() {
-  if (arguments.length > 100) console.log('damn');
-}
+  function handle() {
+    if (arguments.length > 100) console.log('damn');
+  }
 
-var ee1 = new EventEmitter1()
-  , ee2 = new EventEmitter2()
-  , ee3 = new EventEmitter3()
-  , master = new Master()
-  , drip = new Drip()
-  , fe = new FE()
-  , ce = CE()
-  , ee = EE()
-  , et = new ET();
+  var ee1 = new EventEmitter1()
+    , ee2 = new EventEmitter2()
+    , ee3 = new EventEmitter3()
+    , master = new Master()
+    , drip = new Drip()
+    , fe = new FE()
+    , ce = CE()
+    , ee = EE()
+    , et = new ET();
 
-et.on('foo', handle);
-ee.on('foo', handle);
-fe.on('foo', handle);
-ee3.on('foo', handle);
-ee2.on('foo', handle);
-ee1.on('foo', handle);
-drip.on('foo', handle);
-master.on('foo', handle);
-ce.on('foo', handle);
+  et.on('foo', handle);
+  ee.on('foo', handle);
+  fe.on('foo', handle);
+  ee3.on('foo', handle);
+  ee2.on('foo', handle);
+  ee1.on('foo', handle);
+  drip.on('foo', handle);
+  master.on('foo', handle);
+  ce.on('foo', handle);
 
-(
-  new benchmark.Suite()
-).add('EventEmitter1', function() {
-  ee1.emit('foo');
-  ee1.emit('foo', 'bar');
-  ee1.emit('foo', 'bar', 'baz');
-  ee1.emit('foo', 'bar', 'baz', 'boom');
-}).add('EventEmitter2', function() {
-  ee2.emit('foo');
-  ee2.emit('foo', 'bar');
-  ee2.emit('foo', 'bar', 'baz');
-  ee2.emit('foo', 'bar', 'baz', 'boom');
-}).add('EventEmitter3@0.1.6', function() {
-  ee3.emit('foo');
-  ee3.emit('foo', 'bar');
-  ee3.emit('foo', 'bar', 'baz');
-  ee3.emit('foo', 'bar', 'baz', 'boom');
-}).add('EventEmitter3(master)', function() {
-  master.emit('foo');
-  master.emit('foo', 'bar');
-  master.emit('foo', 'bar', 'baz');
-  master.emit('foo', 'bar', 'baz', 'boom');
-}).add('Drip', function() {
-  drip.emit('foo');
-  drip.emit('foo', 'bar');
-  drip.emit('foo', 'bar', 'baz');
-  drip.emit('foo', 'bar', 'baz', 'boom');
-}).add('fastemitter', function() {
-  fe.emit('foo');
-  fe.emit('foo', 'bar');
-  fe.emit('foo', 'bar', 'baz');
-  fe.emit('foo', 'bar', 'baz', 'boom');
-}).add('event-emitter', function() {
-  ee.emit('foo');
-  ee.emit('foo', 'bar');
-  ee.emit('foo', 'bar', 'baz');
-  ee.emit('foo', 'bar', 'baz', 'boom');
-}).add('contra/emitter', function() {
-  ce.emit('foo');
-  ce.emit('foo', 'bar');
-  ce.emit('foo', 'bar', 'baz');
-  ce.emit('foo', 'bar', 'baz', 'boom');
-}).add('Emittery', function() {
-  et.emit('foo');
-  et.emit('foo', 'bar');
-  et.emit('foo', 'bar', 'baz');
-  et.emit('foo', 'bar', 'baz', 'boom');
-}).on('cycle', function cycle(e) {
-  console.log(e.target.toString());
-}).on('complete', function completed() {
-  console.log('Fastest is %s', this.filter('fastest').map('name'));
-}).run({ async: true });
+  (
+    new benchmark.Suite()
+  ).add('EventEmitter1', function() {
+    ee1.emit('foo');
+    ee1.emit('foo', 'bar');
+    ee1.emit('foo', 'bar', 'baz');
+    ee1.emit('foo', 'bar', 'baz', 'boom');
+  }).add('EventEmitter2', function() {
+    ee2.emit('foo');
+    ee2.emit('foo', 'bar');
+    ee2.emit('foo', 'bar', 'baz');
+    ee2.emit('foo', 'bar', 'baz', 'boom');
+  }).add('EventEmitter3@0.1.6', function() {
+    ee3.emit('foo');
+    ee3.emit('foo', 'bar');
+    ee3.emit('foo', 'bar', 'baz');
+    ee3.emit('foo', 'bar', 'baz', 'boom');
+  }).add('EventEmitter3(master)', function() {
+    master.emit('foo');
+    master.emit('foo', 'bar');
+    master.emit('foo', 'bar', 'baz');
+    master.emit('foo', 'bar', 'baz', 'boom');
+  }).add('Drip', function() {
+    drip.emit('foo');
+    drip.emit('foo', 'bar');
+    drip.emit('foo', 'bar', 'baz');
+    drip.emit('foo', 'bar', 'baz', 'boom');
+  }).add('fastemitter', function() {
+    fe.emit('foo');
+    fe.emit('foo', 'bar');
+    fe.emit('foo', 'bar', 'baz');
+    fe.emit('foo', 'bar', 'baz', 'boom');
+  }).add('event-emitter', function() {
+    ee.emit('foo');
+    ee.emit('foo', 'bar');
+    ee.emit('foo', 'bar', 'baz');
+    ee.emit('foo', 'bar', 'baz', 'boom');
+  }).add('contra/emitter', function() {
+    ce.emit('foo');
+    ce.emit('foo', 'bar');
+    ce.emit('foo', 'bar', 'baz');
+    ce.emit('foo', 'bar', 'baz', 'boom');
+  }).add('Emittery', function() {
+    et.emit('foo');
+    et.emit('foo', 'bar');
+    et.emit('foo', 'bar', 'baz');
+    et.emit('foo', 'bar', 'baz', 'boom');
+  }).on('cycle', function cycle(e) {
+    console.log(e.target.toString());
+  }).on('complete', function completed() {
+    console.log('Fastest is %s', this.filter('fastest').map('name'));
+  }).run({ async: true });
+
+})();

--- a/benchmarks/run/emit.js
+++ b/benchmarks/run/emit.js
@@ -23,7 +23,7 @@ var ee1 = new EventEmitter1()
   , drip = new Drip()
   , fe = new FE()
   , ce = CE()
-  , ee = EE(),
+  , ee = EE()
   , et = new ET();
 
 et.on('foo', handle);

--- a/benchmarks/run/emit.js
+++ b/benchmarks/run/emit.js
@@ -4,7 +4,7 @@
   var benchmark = require('benchmark');
 
   var EventEmitter2 = require('eventemitter2').EventEmitter2
-    , EventEmitter1 = require('events').EventEmitter
+    , EventEmitter1 = require('node:events').EventEmitter
     , EventEmitter3 = require('eventemitter3')
     , Drip = require('drip').EventEmitter
     , CE = require('contra/emitter')

--- a/benchmarks/run/emit.js
+++ b/benchmarks/run/emit.js
@@ -9,6 +9,7 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
   , CE = require('contra/emitter')
   , EE = require('event-emitter')
   , FE = require('fastemitter')
+  , ET = require('emittery')
   , Master = require('../../');
 
 function handle() {
@@ -22,8 +23,10 @@ var ee1 = new EventEmitter1()
   , drip = new Drip()
   , fe = new FE()
   , ce = CE()
-  , ee = EE();
+  , ee = EE(),
+  , et = new ET();
 
+et.on('foo', handle);
 ee.on('foo', handle);
 fe.on('foo', handle);
 ee3.on('foo', handle);
@@ -75,6 +78,11 @@ ce.on('foo', handle);
   ce.emit('foo', 'bar');
   ce.emit('foo', 'bar', 'baz');
   ce.emit('foo', 'bar', 'baz', 'boom');
+}).add('Emittery', function() {
+  et.emit('foo');
+  et.emit('foo', 'bar');
+  et.emit('foo', 'bar', 'baz');
+  et.emit('foo', 'bar', 'baz', 'boom');
 }).on('cycle', function cycle(e) {
   console.log(e.target.toString());
 }).on('complete', function completed() {

--- a/benchmarks/run/hundreds.js
+++ b/benchmarks/run/hundreds.js
@@ -4,7 +4,7 @@
   var benchmark = require('benchmark');
 
   var EventEmitter2 = require('eventemitter2').EventEmitter2
-    , EventEmitter1 = require('events').EventEmitter
+    , EventEmitter1 = require('node:events').EventEmitter
     , EventEmitter3 = require('eventemitter3')
     , Drip = require('drip').EventEmitter
     , CE = require('contra/emitter')

--- a/benchmarks/run/hundreds.js
+++ b/benchmarks/run/hundreds.js
@@ -9,6 +9,7 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
   , CE = require('contra/emitter')
   , EE = require('event-emitter')
   , FE = require('fastemitter')
+  , ET = require('emittery')
   , Master = require('../../');
 
 function foo() {
@@ -25,10 +26,12 @@ var ee1 = new EventEmitter1()
   , fe = new FE()
   , ce = CE()
   , ee = EE()
+  , et = ET()
   , j, i;
 
 for (i = 0; i < 10; i++) {
   for (j = 0; j < 10; j++) {
+    et.on('event:' + i, foo);
     ce.on('event:' + i, foo);
     ee.on('event:' + i, foo);
     fe.on('event:' + i, foo);
@@ -73,6 +76,10 @@ for (i = 0; i < 10; i++) {
 }).add('contra/emitter', function() {
   for (i = 0; i < 10; i++) {
     ce.emit('event:' + i);
+  }
+}).add('Emittery', function() {
+  for (i = 0; i < 10; i++) {
+    et.emit('event:' + i);
   }
 }).on('cycle', function cycle(e) {
   console.log(e.target.toString());

--- a/benchmarks/run/hundreds.js
+++ b/benchmarks/run/hundreds.js
@@ -1,88 +1,91 @@
 'use strict';
 
-var benchmark = require('benchmark');
+(async () => {
+  var benchmark = require('benchmark');
 
-var EventEmitter2 = require('eventemitter2').EventEmitter2
-  , EventEmitter1 = require('events').EventEmitter
-  , EventEmitter3 = require('eventemitter3')
-  , Drip = require('drip').EventEmitter
-  , CE = require('contra/emitter')
-  , EE = require('event-emitter')
-  , FE = require('fastemitter')
-  , ET = require('emittery')
-  , Master = require('../../');
+  var EventEmitter2 = require('eventemitter2').EventEmitter2
+    , EventEmitter1 = require('events').EventEmitter
+    , EventEmitter3 = require('eventemitter3')
+    , Drip = require('drip').EventEmitter
+    , CE = require('contra/emitter')
+    , EE = require('event-emitter')
+    , FE = require('fastemitter')
+    , ET = (await import('emittery')).default
+    , Master = require('../../');
 
-function foo() {
-  if (arguments.length > 100) console.log('damn');
+  function foo() {
+    if (arguments.length > 100) console.log('damn');
 
-  return 1;
-}
+    return 1;
+  }
 
-var ee1 = new EventEmitter1()
-  , ee2 = new EventEmitter2()
-  , ee3 = new EventEmitter3()
-  , master = new Master()
-  , drip = new Drip()
-  , fe = new FE()
-  , ce = CE()
-  , ee = EE()
-  , et = ET()
-  , j, i;
+  var ee1 = new EventEmitter1()
+    , ee2 = new EventEmitter2()
+    , ee3 = new EventEmitter3()
+    , master = new Master()
+    , drip = new Drip()
+    , fe = new FE()
+    , ce = CE()
+    , ee = EE()
+    , et = ET()
+    , j, i;
 
-for (i = 0; i < 10; i++) {
-  for (j = 0; j < 10; j++) {
-    et.on('event:' + i, foo);
-    ce.on('event:' + i, foo);
-    ee.on('event:' + i, foo);
-    fe.on('event:' + i, foo);
-    ee1.on('event:' + i, foo);
-    ee2.on('event:' + i, foo);
-    ee3.on('event:' + i, foo);
-    drip.on('event:' + i, foo);
-    master.on('event:' + i, foo);
+  for (i = 0; i < 10; i++) {
+    for (j = 0; j < 10; j++) {
+      et.on('event:' + i, foo);
+      ce.on('event:' + i, foo);
+      ee.on('event:' + i, foo);
+      fe.on('event:' + i, foo);
+      ee1.on('event:' + i, foo);
+      ee2.on('event:' + i, foo);
+      ee3.on('event:' + i, foo);
+      drip.on('event:' + i, foo);
+      master.on('event:' + i, foo);
+    }
   }
-}
 
-(
-  new benchmark.Suite()
-).add('EventEmitter1', function() {
-  for (i = 0; i < 10; i++) {
-    ee1.emit('event:' + i);
-  }
-}).add('EventEmitter2', function() {
-  for (i = 0; i < 10; i++) {
-    ee2.emit('event:' + i);
-  }
-}).add('EventEmitter3@0.1.6', function() {
-  for (i = 0; i < 10; i++) {
-    ee3.emit('event:' + i);
-  }
-}).add('EventEmitter3(master)', function() {
-  for (i = 0; i < 10; i++) {
-    master.emit('event:' + i);
-  }
-}).add('Drip', function() {
-  for (i = 0; i < 10; i++) {
-    drip.emit('event:' + i);
-  }
-}).add('fastemitter', function() {
-  for (i = 0; i < 10; i++) {
-    fe.emit('event:' + i);
-  }
-}).add('event-emitter', function() {
-  for (i = 0; i < 10; i++) {
-    ee.emit('event:' + i);
-  }
-}).add('contra/emitter', function() {
-  for (i = 0; i < 10; i++) {
-    ce.emit('event:' + i);
-  }
-}).add('Emittery', function() {
-  for (i = 0; i < 10; i++) {
-    et.emit('event:' + i);
-  }
-}).on('cycle', function cycle(e) {
-  console.log(e.target.toString());
-}).on('complete', function completed() {
-  console.log('Fastest is %s', this.filter('fastest').map('name'));
-}).run({ async: true });
+  (
+    new benchmark.Suite()
+  ).add('EventEmitter1', function() {
+    for (i = 0; i < 10; i++) {
+      ee1.emit('event:' + i);
+    }
+  }).add('EventEmitter2', function() {
+    for (i = 0; i < 10; i++) {
+      ee2.emit('event:' + i);
+    }
+  }).add('EventEmitter3@0.1.6', function() {
+    for (i = 0; i < 10; i++) {
+      ee3.emit('event:' + i);
+    }
+  }).add('EventEmitter3(master)', function() {
+    for (i = 0; i < 10; i++) {
+      master.emit('event:' + i);
+    }
+  }).add('Drip', function() {
+    for (i = 0; i < 10; i++) {
+      drip.emit('event:' + i);
+    }
+  }).add('fastemitter', function() {
+    for (i = 0; i < 10; i++) {
+      fe.emit('event:' + i);
+    }
+  }).add('event-emitter', function() {
+    for (i = 0; i < 10; i++) {
+      ee.emit('event:' + i);
+    }
+  }).add('contra/emitter', function() {
+    for (i = 0; i < 10; i++) {
+      ce.emit('event:' + i);
+    }
+  }).add('Emittery', function() {
+    for (i = 0; i < 10; i++) {
+      et.emit('event:' + i);
+    }
+  }).on('cycle', function cycle(e) {
+    console.log(e.target.toString());
+  }).on('complete', function completed() {
+    console.log('Fastest is %s', this.filter('fastest').map('name'));
+  }).run({ async: true });
+
+})();

--- a/benchmarks/run/hundreds.js
+++ b/benchmarks/run/hundreds.js
@@ -27,7 +27,7 @@
     , fe = new FE()
     , ce = CE()
     , ee = EE()
-    , et = ET()
+    , et = new ET()
     , j, i;
 
   for (i = 0; i < 10; i++) {

--- a/benchmarks/run/init.js
+++ b/benchmarks/run/init.js
@@ -4,7 +4,7 @@
   var benchmark = require('benchmark');
 
   var EventEmitter2 = require('eventemitter2').EventEmitter2
-    , EventEmitter1 = require('events').EventEmitter
+    , EventEmitter1 = require('node:events').EventEmitter
     , EventEmitter3 = require('eventemitter3')
     , Drip = require('drip').EventEmitter
     , CE = require('contra/emitter')

--- a/benchmarks/run/init.js
+++ b/benchmarks/run/init.js
@@ -9,6 +9,7 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
   , CE = require('contra/emitter')
   , EE = require('event-emitter')
   , FE = require('fastemitter')
+  , ET = require('emittery')
   , Master = require('../../');
 
 //
@@ -35,6 +36,8 @@ var emitter;
   emitter = EE();
 }).add('contra/emitter', function() {
   emitter = CE();
+}).add('Emittery', function() {
+  emitter = new ET();
 }).on('cycle', function cycle(e) {
   console.log(e.target.toString());
 }).on('complete', function completed() {

--- a/benchmarks/run/init.js
+++ b/benchmarks/run/init.js
@@ -1,45 +1,48 @@
 'use strict';
 
-var benchmark = require('benchmark');
+(async () => {
+  var benchmark = require('benchmark');
 
-var EventEmitter2 = require('eventemitter2').EventEmitter2
-  , EventEmitter1 = require('events').EventEmitter
-  , EventEmitter3 = require('eventemitter3')
-  , Drip = require('drip').EventEmitter
-  , CE = require('contra/emitter')
-  , EE = require('event-emitter')
-  , FE = require('fastemitter')
-  , ET = require('emittery')
-  , Master = require('../../');
+  var EventEmitter2 = require('eventemitter2').EventEmitter2
+    , EventEmitter1 = require('events').EventEmitter
+    , EventEmitter3 = require('eventemitter3')
+    , Drip = require('drip').EventEmitter
+    , CE = require('contra/emitter')
+    , EE = require('event-emitter')
+    , FE = require('fastemitter')
+    , ET = (await import('emittery')).default
+    , Master = require('../../');
 
-//
-// This is used to prevent the functions below from being transformed into
-// noops.
-//
-var emitter;
+  //
+  // This is used to prevent the functions below from being transformed into
+  // noops.
+  //
+  var emitter;
 
-(
-  new benchmark.Suite()
-).add('EventEmitter1', function() {
-  emitter = new EventEmitter1();
-}).add('EventEmitter2', function() {
-  emitter = new EventEmitter2();
-}).add('EventEmitter3@0.1.6', function() {
-  emitter = new EventEmitter3();
-}).add('EventEmitter3(master)', function() {
-  emitter = new Master();
-}).add('Drip', function() {
-  emitter = new Drip();
-}).add('fastemitter', function() {
-  emitter = new FE();
-}).add('event-emitter', function() {
-  emitter = EE();
-}).add('contra/emitter', function() {
-  emitter = CE();
-}).add('Emittery', function() {
-  emitter = new ET();
-}).on('cycle', function cycle(e) {
-  console.log(e.target.toString());
-}).on('complete', function completed() {
-  console.log('Fastest is %s', this.filter('fastest').map('name'));
-}).run({ async: true });
+  (
+    new benchmark.Suite()
+  ).add('EventEmitter1', function() {
+    emitter = new EventEmitter1();
+  }).add('EventEmitter2', function() {
+    emitter = new EventEmitter2();
+  }).add('EventEmitter3@0.1.6', function() {
+    emitter = new EventEmitter3();
+  }).add('EventEmitter3(master)', function() {
+    emitter = new Master();
+  }).add('Drip', function() {
+    emitter = new Drip();
+  }).add('fastemitter', function() {
+    emitter = new FE();
+  }).add('event-emitter', function() {
+    emitter = EE();
+  }).add('contra/emitter', function() {
+    emitter = CE();
+  }).add('Emittery', function() {
+    emitter = new ET();
+  }).on('cycle', function cycle(e) {
+    console.log(e.target.toString());
+  }).on('complete', function completed() {
+    console.log('Fastest is %s', this.filter('fastest').map('name'));
+  }).run({ async: true });
+
+})();

--- a/benchmarks/run/listeners.js
+++ b/benchmarks/run/listeners.js
@@ -5,6 +5,7 @@ var benchmark = require('benchmark');
 var EventEmitter1 = require('events').EventEmitter
   , EventEmitter3 = require('eventemitter3')
   , FE = require('fastemitter')
+  , ET = require('emittery')
   , Master = require('../../');
 
 var MAX_LISTENERS = Math.pow(2, 32) - 1;
@@ -16,16 +17,19 @@ function handle() {
 var ee1 = new EventEmitter1()
   , ee3 = new EventEmitter3()
   , master = new Master()
-  , fe = new FE();
+  , fe = new FE()
+  , et = new ET();
 
 ee1.setMaxListeners(MAX_LISTENERS);
 fe.setMaxListeners(MAX_LISTENERS);
+et.listenerCount(MAX_LISTENERS);
 
 for (var i = 0; i < 25; i++) {
   ee1.on('event', handle);
   ee3.on('event', handle);
   master.on('event', handle);
   fe.on('event', handle);
+  et.on('event', handle);
 }
 
 //
@@ -45,6 +49,8 @@ for (var i = 0; i < 25; i++) {
   master.listeners('event');
 }).add('fastemitter', function() {
   fe.listeners('event');
+}).add('Emittery', function() {
+  et.getListeners('event');
 }).on('cycle', function cycle(e) {
   console.log(e.target.toString());
 }).on('complete', function completed() {

--- a/benchmarks/run/listeners.js
+++ b/benchmarks/run/listeners.js
@@ -3,7 +3,7 @@
 (async () => {
   var benchmark = require('benchmark');
 
-  var EventEmitter1 = require('events').EventEmitter
+  var EventEmitter1 = require('node:events').EventEmitter
     , EventEmitter3 = require('eventemitter3')
     , FE = require('fastemitter')
     , ET = (await import('emittery')).default

--- a/benchmarks/run/listeners.js
+++ b/benchmarks/run/listeners.js
@@ -1,58 +1,61 @@
 'use strict';
 
-var benchmark = require('benchmark');
+(async () => {
+  var benchmark = require('benchmark');
 
-var EventEmitter1 = require('events').EventEmitter
-  , EventEmitter3 = require('eventemitter3')
-  , FE = require('fastemitter')
-  , ET = require('emittery')
-  , Master = require('../../');
+  var EventEmitter1 = require('events').EventEmitter
+    , EventEmitter3 = require('eventemitter3')
+    , FE = require('fastemitter')
+    , ET = (await import('emittery')).default
+    , Master = require('../../');
 
-var MAX_LISTENERS = Math.pow(2, 32) - 1;
+  var MAX_LISTENERS = Math.pow(2, 32) - 1;
 
-function handle() {
-  if (arguments.length > 100) console.log('damn');
-}
+  function handle() {
+    if (arguments.length > 100) console.log('damn');
+  }
 
-var ee1 = new EventEmitter1()
-  , ee3 = new EventEmitter3()
-  , master = new Master()
-  , fe = new FE()
-  , et = new ET();
+  var ee1 = new EventEmitter1()
+    , ee3 = new EventEmitter3()
+    , master = new Master()
+    , fe = new FE()
+    , et = new ET();
 
-ee1.setMaxListeners(MAX_LISTENERS);
-fe.setMaxListeners(MAX_LISTENERS);
-et.listenerCount(MAX_LISTENERS);
+  ee1.setMaxListeners(MAX_LISTENERS);
+  fe.setMaxListeners(MAX_LISTENERS);
+  et.listenerCount(MAX_LISTENERS);
 
-for (var i = 0; i < 25; i++) {
-  ee1.on('event', handle);
-  ee3.on('event', handle);
-  master.on('event', handle);
-  fe.on('event', handle);
-  et.on('event', handle);
-}
+  for (var i = 0; i < 25; i++) {
+    ee1.on('event', handle);
+    ee3.on('event', handle);
+    master.on('event', handle);
+    fe.on('event', handle);
+    et.on('event', handle);
+  }
 
-//
-// eventemitter2 doesn't correctly handle listeners as they can be removed by
-// doing `ee2.listeners('event').length = 0;`. Same counts for Drip.
-//
-// event-emitter and contra/emitter do not implement `listeners`.
-//
+  //
+  // eventemitter2 doesn't correctly handle listeners as they can be removed by
+  // doing `ee2.listeners('event').length = 0;`. Same counts for Drip.
+  //
+  // event-emitter and contra/emitter do not implement `listeners`.
+  //
 
-(
-  new benchmark.Suite()
-).add('EventEmitter1', function () {
-  ee1.listeners('event');
-}).add('EventEmitter3@0.1.6', function() {
-  ee3.listeners('event');
-}).add('EventEmitter3(master)', function() {
-  master.listeners('event');
-}).add('fastemitter', function() {
-  fe.listeners('event');
-}).add('Emittery', function() {
-  et.getListeners('event');
-}).on('cycle', function cycle(e) {
-  console.log(e.target.toString());
-}).on('complete', function completed() {
-  console.log('Fastest is %s', this.filter('fastest').map('name'));
-}).run({ async: true });
+  (
+    new benchmark.Suite()
+  ).add('EventEmitter1', function () {
+    ee1.listeners('event');
+  }).add('EventEmitter3@0.1.6', function() {
+    ee3.listeners('event');
+  }).add('EventEmitter3(master)', function() {
+    master.listeners('event');
+  }).add('fastemitter', function() {
+    fe.listeners('event');
+  }).add('Emittery', function() {
+    et.getListeners('event');
+  }).on('cycle', function cycle(e) {
+    console.log(e.target.toString());
+  }).on('complete', function completed() {
+    console.log('Fastest is %s', this.filter('fastest').map('name'));
+  }).run({ async: true });
+
+})();

--- a/benchmarks/run/once.js
+++ b/benchmarks/run/once.js
@@ -10,7 +10,7 @@
     , CE = require('contra/emitter')
     , EE = require('event-emitter')
     , FE = require('fastemitter')
-    , ET = require('emittery')
+    , ET = (await import('emittery')).default
     , Master = require('../../');
 
   function handle() {

--- a/benchmarks/run/once.js
+++ b/benchmarks/run/once.js
@@ -4,7 +4,7 @@
   var benchmark = require('benchmark');
 
   var EventEmitter2 = require('eventemitter2').EventEmitter2
-    , EventEmitter1 = require('events').EventEmitter
+    , EventEmitter1 = require('node:events').EventEmitter
     , EventEmitter3 = require('eventemitter3')
     , Drip = require('drip').EventEmitter
     , CE = require('contra/emitter')

--- a/benchmarks/run/once.js
+++ b/benchmarks/run/once.js
@@ -9,6 +9,7 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
   , CE = require('contra/emitter')
   , EE = require('event-emitter')
   , FE = require('fastemitter')
+  , ET = require('emittery')
   , Master = require('../../');
 
 function handle() {
@@ -22,7 +23,8 @@ var ee1 = new EventEmitter1()
   , drip = new Drip()
   , fe = new FE()
   , ce = CE()
-  , ee = EE();
+  , ee = EE()
+  , et = new ET();
 
 (
   new benchmark.Suite()
@@ -41,6 +43,8 @@ var ee1 = new EventEmitter1()
 }).add('event-emitter', function() {
   ee.once('foo', handle).emit('foo');
 }).add('contra/emitter', function() {
+  ce.once('foo', handle).emit('foo');
+}).add('Emittery', function() {
   ce.once('foo', handle).emit('foo');
 }).on('cycle', function cycle(e) {
   console.log(e.target.toString());

--- a/benchmarks/run/once.js
+++ b/benchmarks/run/once.js
@@ -1,53 +1,56 @@
 'use strict';
 
-var benchmark = require('benchmark');
+(async () => {
+  var benchmark = require('benchmark');
 
-var EventEmitter2 = require('eventemitter2').EventEmitter2
-  , EventEmitter1 = require('events').EventEmitter
-  , EventEmitter3 = require('eventemitter3')
-  , Drip = require('drip').EventEmitter
-  , CE = require('contra/emitter')
-  , EE = require('event-emitter')
-  , FE = require('fastemitter')
-  , ET = require('emittery')
-  , Master = require('../../');
+  var EventEmitter2 = require('eventemitter2').EventEmitter2
+    , EventEmitter1 = require('events').EventEmitter
+    , EventEmitter3 = require('eventemitter3')
+    , Drip = require('drip').EventEmitter
+    , CE = require('contra/emitter')
+    , EE = require('event-emitter')
+    , FE = require('fastemitter')
+    , ET = require('emittery')
+    , Master = require('../../');
 
-function handle() {
-  if (arguments.length > 100) console.log('damn');
-}
+  function handle() {
+    if (arguments.length > 100) console.log('damn');
+  }
 
-var ee1 = new EventEmitter1()
-  , ee2 = new EventEmitter2()
-  , ee3 = new EventEmitter3()
-  , master = new Master()
-  , drip = new Drip()
-  , fe = new FE()
-  , ce = CE()
-  , ee = EE()
-  , et = new ET();
+  var ee1 = new EventEmitter1()
+    , ee2 = new EventEmitter2()
+    , ee3 = new EventEmitter3()
+    , master = new Master()
+    , drip = new Drip()
+    , fe = new FE()
+    , ce = CE()
+    , ee = EE()
+    , et = new ET();
 
-(
-  new benchmark.Suite()
-).add('EventEmitter1', function() {
-  ee1.once('foo', handle).emit('foo');
-}).add('EventEmitter2', function() {
-  ee2.once('foo', handle).emit('foo');
-}).add('EventEmitter3@0.1.6', function() {
-  ee3.once('foo', handle).emit('foo');
-}).add('EventEmitter3(master)', function() {
-  master.once('foo', handle).emit('foo');
-}).add('Drip', function() {
-  drip.once('foo', handle).emit('foo');
-}).add('fastemitter', function() {
-  fe.once('foo', handle).emit('foo');
-}).add('event-emitter', function() {
-  ee.once('foo', handle).emit('foo');
-}).add('contra/emitter', function() {
-  ce.once('foo', handle).emit('foo');
-}).add('Emittery', function() {
-  ce.once('foo', handle).emit('foo');
-}).on('cycle', function cycle(e) {
-  console.log(e.target.toString());
-}).on('complete', function completed() {
-  console.log('Fastest is %s', this.filter('fastest').map('name'));
-}).run({ async: true });
+  (
+    new benchmark.Suite()
+  ).add('EventEmitter1', function() {
+    ee1.once('foo', handle).emit('foo');
+  }).add('EventEmitter2', function() {
+    ee2.once('foo', handle).emit('foo');
+  }).add('EventEmitter3@0.1.6', function() {
+    ee3.once('foo', handle).emit('foo');
+  }).add('EventEmitter3(master)', function() {
+    master.once('foo', handle).emit('foo');
+  }).add('Drip', function() {
+    drip.once('foo', handle).emit('foo');
+  }).add('fastemitter', function() {
+    fe.once('foo', handle).emit('foo');
+  }).add('event-emitter', function() {
+    ee.once('foo', handle).emit('foo');
+  }).add('contra/emitter', function() {
+    ce.once('foo', handle).emit('foo');
+  }).add('Emittery', function() {
+    ce.once('foo', handle).emit('foo');
+  }).on('cycle', function cycle(e) {
+    console.log(e.target.toString());
+  }).on('complete', function completed() {
+    console.log('Fastest is %s', this.filter('fastest').map('name'));
+  }).run({ async: true });
+
+})();

--- a/benchmarks/run/remove-emit.js
+++ b/benchmarks/run/remove-emit.js
@@ -4,7 +4,7 @@
   var benchmark = require('benchmark');
 
   var EventEmitter2 = require('eventemitter2').EventEmitter2
-    , EventEmitter1 = require('events').EventEmitter
+    , EventEmitter1 = require('node:events').EventEmitter
     , EventEmitter3 = require('eventemitter3')
     , Drip = require('drip').EventEmitter
     , CE = require('contra/emitter')

--- a/benchmarks/run/remove-emit.js
+++ b/benchmarks/run/remove-emit.js
@@ -9,7 +9,7 @@
     , Drip = require('drip').EventEmitter
     , CE = require('contra/emitter')
     , EE = require('event-emitter')
-    , ET = (await require('emittery')).default
+    , ET = (await import('emittery')).default
     , Master = require('../../');
 
   function handle() {

--- a/benchmarks/run/remove-emit.js
+++ b/benchmarks/run/remove-emit.js
@@ -21,7 +21,7 @@ var ee1 = new EventEmitter1()
   , master = new Master()
   , drip = new Drip()
   , ce = CE()
-  , ee = EE();
+  , ee = EE()
   , et = new ET();
 
 [ee1, ee2, ee3, master, drip, ee, ce, et].forEach(function ohai(emitter) {

--- a/benchmarks/run/remove-emit.js
+++ b/benchmarks/run/remove-emit.js
@@ -8,6 +8,7 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
   , Drip = require('drip').EventEmitter
   , CE = require('contra/emitter')
   , EE = require('event-emitter')
+  , ET = require('emittery')
   , Master = require('../../');
 
 function handle() {
@@ -21,8 +22,9 @@ var ee1 = new EventEmitter1()
   , drip = new Drip()
   , ce = CE()
   , ee = EE();
+  , et = new ET();
 
-[ee1, ee2, ee3, master, drip, ee, ce].forEach(function ohai(emitter) {
+[ee1, ee2, ee3, master, drip, ee, ce, et].forEach(function ohai(emitter) {
   emitter.on('foo', handle);
 
   //
@@ -76,6 +78,11 @@ var ee1 = new EventEmitter1()
   ce.emit('foo', 'bar');
   ce.emit('foo', 'bar', 'baz');
   ce.emit('foo', 'bar', 'baz', 'boom');
+}).add('Emittery', function() {
+  et.emit('foo');
+  et.emit('foo', 'bar');
+  et.emit('foo', 'bar', 'baz');
+  et.emit('foo', 'bar', 'baz', 'boom');
 }).on('cycle', function cycle(e) {
   console.log(e.target.toString());
 }).on('complete', function completed() {

--- a/benchmarks/run/remove-emit.js
+++ b/benchmarks/run/remove-emit.js
@@ -1,90 +1,93 @@
 'use strict';
 
-var benchmark = require('benchmark');
+(async () => {
+  var benchmark = require('benchmark');
 
-var EventEmitter2 = require('eventemitter2').EventEmitter2
-  , EventEmitter1 = require('events').EventEmitter
-  , EventEmitter3 = require('eventemitter3')
-  , Drip = require('drip').EventEmitter
-  , CE = require('contra/emitter')
-  , EE = require('event-emitter')
-  , ET = require('emittery')
-  , Master = require('../../');
+  var EventEmitter2 = require('eventemitter2').EventEmitter2
+    , EventEmitter1 = require('events').EventEmitter
+    , EventEmitter3 = require('eventemitter3')
+    , Drip = require('drip').EventEmitter
+    , CE = require('contra/emitter')
+    , EE = require('event-emitter')
+    , ET = (await require('emittery')).default
+    , Master = require('../../');
 
-function handle() {
-  if (arguments.length > 100) console.log('damn');
-}
+  function handle() {
+    if (arguments.length > 100) console.log('damn');
+  }
 
-var ee1 = new EventEmitter1()
-  , ee2 = new EventEmitter2()
-  , ee3 = new EventEmitter3()
-  , master = new Master()
-  , drip = new Drip()
-  , ce = CE()
-  , ee = EE()
-  , et = new ET();
+  var ee1 = new EventEmitter1()
+    , ee2 = new EventEmitter2()
+    , ee3 = new EventEmitter3()
+    , master = new Master()
+    , drip = new Drip()
+    , ce = CE()
+    , ee = EE()
+    , et = new ET();
 
-[ee1, ee2, ee3, master, drip, ee, ce, et].forEach(function ohai(emitter) {
-  emitter.on('foo', handle);
+  [ee1, ee2, ee3, master, drip, ee, ce, et].forEach(function ohai(emitter) {
+    emitter.on('foo', handle);
+
+    //
+    // We add and remove a listener to see if the event emitter implementation is
+    // de-optimized because it deletes items from an object etc.
+    //
+    emitter.on('ohai', ohai);
+    if (emitter.removeListener) emitter.removeListener('ohai', ohai);
+    else if (emitter.off) emitter.off('ohai', ohai);
+    else throw new Error('No proper remove implementation');
+  });
 
   //
-  // We add and remove a listener to see if the event emitter implementation is
-  // de-optimized because it deletes items from an object etc.
+  // FastEmitter is omitted as it throws an error.
   //
-  emitter.on('ohai', ohai);
-  if (emitter.removeListener) emitter.removeListener('ohai', ohai);
-  else if (emitter.off) emitter.off('ohai', ohai);
-  else throw new Error('No proper remove implementation');
-});
 
-//
-// FastEmitter is omitted as it throws an error.
-//
+  (
+    new benchmark.Suite()
+  ).add('EventEmitter1', function() {
+    ee1.emit('foo');
+    ee1.emit('foo', 'bar');
+    ee1.emit('foo', 'bar', 'baz');
+    ee1.emit('foo', 'bar', 'baz', 'boom');
+  }).add('EventEmitter2', function() {
+    ee2.emit('foo');
+    ee2.emit('foo', 'bar');
+    ee2.emit('foo', 'bar', 'baz');
+    ee2.emit('foo', 'bar', 'baz', 'boom');
+  }).add('EventEmitter3@0.1.6', function() {
+    ee3.emit('foo');
+    ee3.emit('foo', 'bar');
+    ee3.emit('foo', 'bar', 'baz');
+    ee3.emit('foo', 'bar', 'baz', 'boom');
+  }).add('EventEmitter3(master)', function() {
+    master.emit('foo');
+    master.emit('foo', 'bar');
+    master.emit('foo', 'bar', 'baz');
+    master.emit('foo', 'bar', 'baz', 'boom');
+  }).add('Drip', function() {
+    drip.emit('foo');
+    drip.emit('foo', 'bar');
+    drip.emit('foo', 'bar', 'baz');
+    drip.emit('foo', 'bar', 'baz', 'boom');
+  }).add('event-emitter', function() {
+    ee.emit('foo');
+    ee.emit('foo', 'bar');
+    ee.emit('foo', 'bar', 'baz');
+    ee.emit('foo', 'bar', 'baz', 'boom');
+  }).add('contra/emitter', function() {
+    ce.emit('foo');
+    ce.emit('foo', 'bar');
+    ce.emit('foo', 'bar', 'baz');
+    ce.emit('foo', 'bar', 'baz', 'boom');
+  }).add('Emittery', function() {
+    et.emit('foo');
+    et.emit('foo', 'bar');
+    et.emit('foo', 'bar', 'baz');
+    et.emit('foo', 'bar', 'baz', 'boom');
+  }).on('cycle', function cycle(e) {
+    console.log(e.target.toString());
+  }).on('complete', function completed() {
+    console.log('Fastest is %s', this.filter('fastest').map('name'));
+  }).run({ async: true });
 
-(
-  new benchmark.Suite()
-).add('EventEmitter1', function() {
-  ee1.emit('foo');
-  ee1.emit('foo', 'bar');
-  ee1.emit('foo', 'bar', 'baz');
-  ee1.emit('foo', 'bar', 'baz', 'boom');
-}).add('EventEmitter2', function() {
-  ee2.emit('foo');
-  ee2.emit('foo', 'bar');
-  ee2.emit('foo', 'bar', 'baz');
-  ee2.emit('foo', 'bar', 'baz', 'boom');
-}).add('EventEmitter3@0.1.6', function() {
-  ee3.emit('foo');
-  ee3.emit('foo', 'bar');
-  ee3.emit('foo', 'bar', 'baz');
-  ee3.emit('foo', 'bar', 'baz', 'boom');
-}).add('EventEmitter3(master)', function() {
-  master.emit('foo');
-  master.emit('foo', 'bar');
-  master.emit('foo', 'bar', 'baz');
-  master.emit('foo', 'bar', 'baz', 'boom');
-}).add('Drip', function() {
-  drip.emit('foo');
-  drip.emit('foo', 'bar');
-  drip.emit('foo', 'bar', 'baz');
-  drip.emit('foo', 'bar', 'baz', 'boom');
-}).add('event-emitter', function() {
-  ee.emit('foo');
-  ee.emit('foo', 'bar');
-  ee.emit('foo', 'bar', 'baz');
-  ee.emit('foo', 'bar', 'baz', 'boom');
-}).add('contra/emitter', function() {
-  ce.emit('foo');
-  ce.emit('foo', 'bar');
-  ce.emit('foo', 'bar', 'baz');
-  ce.emit('foo', 'bar', 'baz', 'boom');
-}).add('Emittery', function() {
-  et.emit('foo');
-  et.emit('foo', 'bar');
-  et.emit('foo', 'bar', 'baz');
-  et.emit('foo', 'bar', 'baz', 'boom');
-}).on('cycle', function cycle(e) {
-  console.log(e.target.toString());
-}).on('complete', function completed() {
-  console.log('Fastest is %s', this.filter('fastest').map('name'));
-}).run({ async: true });
+})();


### PR DESCRIPTION
This PR adds [Emittery](https://www.npmjs.com/package/emittery) to the benchmarks.

Some minor modifications had to be done in order to support importing ESM module, which was done by wrapping an async IIFE around the tests.

There was one other problem too though: `package.json` never had `events` listed in the packages for  `EventEmitter1`, so the tests would always throw an error. This was also added, along with the Emittery dependency.

Not sure if test results will be generated by an automated workflow, but I have noted down the results of the benchmarks if needed.