### PR TITLE
Add benchmark for tseep and fix arm64 install issue.

### DIFF
--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -16,6 +16,8 @@
     "event-emitter": "latest",
     "eventemitter2": "latest",
     "eventemitter3": "0.1.6",
-    "fastemitter": "latest"
+    "fastemitter": "latest",
+    "browserify-events": "npm:events@3.3.0",
+    "tseep": "latest"
   }
 }

--- a/benchmarks/run/add-remove.js
+++ b/benchmarks/run/add-remove.js
@@ -9,6 +9,8 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
   , CE = require('contra/emitter')
   , EE = require('event-emitter')
   , FE = require('fastemitter')
+  , BrowserifyEmitter = require('browserify-events')
+  , Tseep = require('tseep').EventEmitter
   , Master = require('../../');
 
 function handle() {
@@ -21,6 +23,8 @@ var ee1 = new EventEmitter1()
   , master = new Master()
   , drip = new Drip()
   , fe = new FE()
+  , be = new BrowserifyEmitter()
+  , te = new Tseep()
   , ce = CE()
   , ee = EE();
 
@@ -44,6 +48,12 @@ var ee1 = new EventEmitter1()
 }).add('fastemitter', function() {
   fe.on('foo', handle);
   fe.removeListener('foo', handle);
+}).add('browserify-events', function() {
+  be.on('foo', handle);
+  be.removeListener('foo', handle);
+}).add('tseep', function() {
+  te.on('foo', handle);
+  te.removeListener('foo', handle);
 }).add('event-emitter', function() {
   ee.on('foo', handle);
   ee.off('foo', handle);

--- a/benchmarks/run/context.js
+++ b/benchmarks/run/context.js
@@ -9,6 +9,8 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
   , CE = require('contra/emitter')
   , EE = require('event-emitter')
   , FE = require('fastemitter')
+  , BrowserifyEmitter = require('browserify-events')
+  , Tseep = require('tseep').EventEmitter
   , Master = require('../../');
 
 var ctx = { foo: 'bar' };
@@ -23,6 +25,8 @@ var ee1 = new EventEmitter1()
   , master = new Master()
   , drip = new Drip()
   , fe = new FE()
+  , be = new BrowserifyEmitter()
+  , te = new Tseep()
   , ce = CE()
   , ee = EE();
 
@@ -33,6 +37,8 @@ drip.on('foo', handle.bind(ctx));
 master.on('foo', handle, ctx);
 ee.on('foo', handle.bind(ctx));
 fe.on('foo', handle.bind(ctx));
+be.on('foo', handle.bind(ctx));
+te.on('foo', handle.bind(ctx));
 ce.on('foo', handle.bind(ctx));
 
 (
@@ -67,6 +73,16 @@ ce.on('foo', handle.bind(ctx));
   fe.emit('foo', 'bar');
   fe.emit('foo', 'bar', 'baz');
   fe.emit('foo', 'bar', 'baz', 'boom');
+}).add('browserify-events', function() {
+  be.emit('foo');
+  be.emit('foo', 'bar');
+  be.emit('foo', 'bar', 'baz');
+  be.emit('foo', 'bar', 'baz', 'boom');
+}).add('tseep', function() {
+  te.emit('foo');
+  te.emit('foo', 'bar');
+  te.emit('foo', 'bar', 'baz');
+  te.emit('foo', 'bar', 'baz', 'boom');
 }).add('event-emitter', function() {
   ee.emit('foo');
   ee.emit('foo', 'bar');

--- a/benchmarks/run/emit-multiple-listeners.js
+++ b/benchmarks/run/emit-multiple-listeners.js
@@ -8,6 +8,8 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
   , CE = require('contra/emitter')
   , EE = require('event-emitter')
   , FE = require('fastemitter')
+  , BrowserifyEmitter = require('browserify-events')
+  , Tseep = require('tseep').EventEmitter
   , Master = require('../../');
 
 function foo() {
@@ -33,12 +35,16 @@ var ee1 = new EventEmitter1()
   , ee3 = new EventEmitter3()
   , master = new Master()
   , fe = new FE()
+  , be = new BrowserifyEmitter()
+  , te = new Tseep()
   , ce = CE()
   , ee = EE();
 
 ce.on('foo', foo).on('foo', bar).on('foo', baz);
 ee.on('foo', foo).on('foo', bar).on('foo', baz);
 fe.on('foo', foo).on('foo', bar).on('foo', baz);
+be.on('foo', foo).on('foo', bar).on('foo', baz);
+te.on('foo', foo).on('foo', bar).on('foo', baz);
 ee3.on('foo', foo).on('foo', bar).on('foo', baz);
 ee2.on('foo', foo).on('foo', bar).on('foo', baz);
 ee1.on('foo', foo).on('foo', bar).on('foo', baz);
@@ -76,6 +82,16 @@ master.on('foo', foo).on('foo', bar).on('foo', baz);
   fe.emit('foo', 'bar');
   fe.emit('foo', 'bar', 'baz');
   fe.emit('foo', 'bar', 'baz', 'boom');
+}).add('browserify-events', function() {
+  be.emit('foo');
+  be.emit('foo', 'bar');
+  be.emit('foo', 'bar', 'baz');
+  be.emit('foo', 'bar', 'baz', 'boom');
+}).add('tseep', function() {
+  te.emit('foo');
+  te.emit('foo', 'bar');
+  te.emit('foo', 'bar', 'baz');
+  te.emit('foo', 'bar', 'baz', 'boom');
 }).add('event-emitter', function() {
   ee.emit('foo');
   ee.emit('foo', 'bar');

--- a/benchmarks/run/emit.js
+++ b/benchmarks/run/emit.js
@@ -9,6 +9,8 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
   , CE = require('contra/emitter')
   , EE = require('event-emitter')
   , FE = require('fastemitter')
+  , BrowserifyEmitter = require('browserify-events')
+  , Tseep = require('tseep').EventEmitter
   , Master = require('../../');
 
 function handle() {
@@ -21,11 +23,15 @@ var ee1 = new EventEmitter1()
   , master = new Master()
   , drip = new Drip()
   , fe = new FE()
+  , be = new BrowserifyEmitter()
+  , te = new Tseep()
   , ce = CE()
   , ee = EE();
 
 ee.on('foo', handle);
 fe.on('foo', handle);
+be.on('foo', handle);
+te.on('foo', handle);
 ee3.on('foo', handle);
 ee2.on('foo', handle);
 ee1.on('foo', handle);
@@ -65,6 +71,16 @@ ce.on('foo', handle);
   fe.emit('foo', 'bar');
   fe.emit('foo', 'bar', 'baz');
   fe.emit('foo', 'bar', 'baz', 'boom');
+}).add('browserify-events', function() {
+  be.emit('foo');
+  be.emit('foo', 'bar');
+  be.emit('foo', 'bar', 'baz');
+  be.emit('foo', 'bar', 'baz', 'boom');
+}).add('tseep', function() {
+  te.emit('foo');
+  te.emit('foo', 'bar');
+  te.emit('foo', 'bar', 'baz');
+  te.emit('foo', 'bar', 'baz', 'boom');
 }).add('event-emitter', function() {
   ee.emit('foo');
   ee.emit('foo', 'bar');

--- a/benchmarks/run/hundreds.js
+++ b/benchmarks/run/hundreds.js
@@ -9,6 +9,8 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
   , CE = require('contra/emitter')
   , EE = require('event-emitter')
   , FE = require('fastemitter')
+  , BrowserifyEmitter = require('browserify-events')
+  , Tseep = require('tseep').EventEmitter
   , Master = require('../../');
 
 function foo() {
@@ -23,6 +25,8 @@ var ee1 = new EventEmitter1()
   , master = new Master()
   , drip = new Drip()
   , fe = new FE()
+  , be = new BrowserifyEmitter()
+  , te = new Tseep()
   , ce = CE()
   , ee = EE()
   , j, i;
@@ -32,6 +36,8 @@ for (i = 0; i < 10; i++) {
     ce.on('event:' + i, foo);
     ee.on('event:' + i, foo);
     fe.on('event:' + i, foo);
+    be.on('event:' + i, foo);
+    te.on('event:' + i, foo);
     ee1.on('event:' + i, foo);
     ee2.on('event:' + i, foo);
     ee3.on('event:' + i, foo);
@@ -65,6 +71,14 @@ for (i = 0; i < 10; i++) {
 }).add('fastemitter', function() {
   for (i = 0; i < 10; i++) {
     fe.emit('event:' + i);
+  }
+}).add('browserify-events', function() {
+  for (i = 0; i < 10; i++) {
+    be.emit('event:' + i);
+  }
+}).add('tseep', function() {
+  for (i = 0; i < 10; i++) {
+    te.emit('event:' + i);
   }
 }).add('event-emitter', function() {
   for (i = 0; i < 10; i++) {

--- a/benchmarks/run/init.js
+++ b/benchmarks/run/init.js
@@ -9,6 +9,8 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
   , CE = require('contra/emitter')
   , EE = require('event-emitter')
   , FE = require('fastemitter')
+  , BrowserifyEmitter = require('browserify-events')
+  , Tseep = require('tseep').EventEmitter
   , Master = require('../../');
 
 //
@@ -31,6 +33,10 @@ var emitter;
   emitter = new Drip();
 }).add('fastemitter', function() {
   emitter = new FE();
+}).add('browserify-events', function() {
+  emitter = new BrowserifyEmitter();
+}).add('tseep', function() {
+  emitter = new Tseep();
 }).add('event-emitter', function() {
   emitter = EE();
 }).add('contra/emitter', function() {

--- a/benchmarks/run/listeners.js
+++ b/benchmarks/run/listeners.js
@@ -5,6 +5,8 @@ var benchmark = require('benchmark');
 var EventEmitter1 = require('events').EventEmitter
   , EventEmitter3 = require('eventemitter3')
   , FE = require('fastemitter')
+  , BrowserifyEmitter = require('browserify-events')
+  , Tseep = require('tseep').EventEmitter
   , Master = require('../../');
 
 var MAX_LISTENERS = Math.pow(2, 32) - 1;
@@ -16,16 +18,22 @@ function handle() {
 var ee1 = new EventEmitter1()
   , ee3 = new EventEmitter3()
   , master = new Master()
-  , fe = new FE();
+  , fe = new FE()
+  , be = new BrowserifyEmitter()
+  , te = new Tseep();
 
 ee1.setMaxListeners(MAX_LISTENERS);
 fe.setMaxListeners(MAX_LISTENERS);
+be.setMaxListeners(MAX_LISTENERS);
+te.setMaxListeners(MAX_LISTENERS);
 
 for (var i = 0; i < 25; i++) {
   ee1.on('event', handle);
   ee3.on('event', handle);
   master.on('event', handle);
   fe.on('event', handle);
+  be.on('event', handle);
+  te.on('event', handle);
 }
 
 //
@@ -45,6 +53,10 @@ for (var i = 0; i < 25; i++) {
   master.listeners('event');
 }).add('fastemitter', function() {
   fe.listeners('event');
+}).add('browserify-events', function() {
+  be.listeners('event');
+}).add('tseep', function() {
+  te.listeners('event');
 }).on('cycle', function cycle(e) {
   console.log(e.target.toString());
 }).on('complete', function completed() {

--- a/benchmarks/run/once.js
+++ b/benchmarks/run/once.js
@@ -9,6 +9,8 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
   , CE = require('contra/emitter')
   , EE = require('event-emitter')
   , FE = require('fastemitter')
+  , BrowserifyEmitter = require('browserify-events')
+  , Tseep = require('tseep').EventEmitter
   , Master = require('../../');
 
 function handle() {
@@ -21,6 +23,8 @@ var ee1 = new EventEmitter1()
   , master = new Master()
   , drip = new Drip()
   , fe = new FE()
+  , be = new BrowserifyEmitter()
+  , te = new Tseep()
   , ce = CE()
   , ee = EE();
 
@@ -38,6 +42,10 @@ var ee1 = new EventEmitter1()
   drip.once('foo', handle).emit('foo');
 }).add('fastemitter', function() {
   fe.once('foo', handle).emit('foo');
+}).add('browserify-events', function() {
+  be.once('foo', handle).emit('foo');
+}).add('tseep', function() {
+  te.once('foo', handle).emit('foo');
 }).add('event-emitter', function() {
   ee.once('foo', handle).emit('foo');
 }).add('contra/emitter', function() {

--- a/benchmarks/run/remove-emit.js
+++ b/benchmarks/run/remove-emit.js
@@ -8,6 +8,8 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
   , Drip = require('drip').EventEmitter
   , CE = require('contra/emitter')
   , EE = require('event-emitter')
+  , BrowserifyEmitter = require('browserify-events')
+  , Tseep = require('tseep').EventEmitter
   , Master = require('../../');
 
 function handle() {
@@ -19,10 +21,12 @@ var ee1 = new EventEmitter1()
   , ee3 = new EventEmitter3()
   , master = new Master()
   , drip = new Drip()
+  , be = new BrowserifyEmitter()
+  , te = new Tseep()
   , ce = CE()
   , ee = EE();
 
-[ee1, ee2, ee3, master, drip, ee, ce].forEach(function ohai(emitter) {
+[ee1, ee2, ee3, master, drip, be, te, ee, ce].forEach(function ohai(emitter) {
   emitter.on('foo', handle);
 
   //
@@ -66,6 +70,16 @@ var ee1 = new EventEmitter1()
   drip.emit('foo', 'bar');
   drip.emit('foo', 'bar', 'baz');
   drip.emit('foo', 'bar', 'baz', 'boom');
+}).add('browserify-events', function() {
+  be.emit('foo');
+  be.emit('foo', 'bar');
+  be.emit('foo', 'bar', 'baz');
+  be.emit('foo', 'bar', 'baz', 'boom');
+}).add('tseep', function() {
+  te.emit('foo');
+  te.emit('foo', 'bar');
+  te.emit('foo', 'bar', 'baz');
+  te.emit('foo', 'bar', 'baz', 'boom');
 }).add('event-emitter', function() {
   ee.emit('foo');
   ee.emit('foo', 'bar');

--- a/package.json
+++ b/package.json
@@ -62,6 +62,6 @@
     "rimraf": "^4.1.2",
     "rollup": "^3.4.0",
     "sauce-browsers": "^3.0.0",
-    "sauce-test": "^1.3.3"
+    "sauce-test": "git+https://github.com/Romick2005/sauce-test.git"
   }
 }


### PR DESCRIPTION
#263 Use forked version of sauce-test to fix npm install for node-chromedriver that supports arm64. 
#257 Add browserify-events and tseep emitters to the benchmarks.