### PR TITLE
[pkg]: provide export for "browser"

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "exports": {
     ".": {
       "types": "./index.d.ts",
+      "browser": "./dist/eventemitter3.esm.js",
       "import": "./index.mjs",
       "require": "./index.js"
     },


### PR DESCRIPTION
We need the built ESM module for the browser for bundlers like vite.

This addresses errors like issue #261:

> index.mjs?v=73fd6c6e:1 Uncaught SyntaxError: The requested module '/node_modules/eventemitter3/index.js?v=73fd6c6e' does not provide an export named 'default' (at index.mjs?v=73fd6c6e:1:8)
