### PR TITLE
Fix typescript types for ESM import

### DIFF
--- a/index.d.mts
+++ b/index.d.mts
@@ -1,0 +1,4 @@
+import type EventEmitter from "./index.d.ts";
+
+export { EventEmitter };
+export default EventEmitter;

--- a/index.d.ts
+++ b/index.d.ts
@@ -131,5 +131,4 @@ declare namespace EventEmitter {
   export const EventEmitter: EventEmitterStatic;
 }
 
-export { EventEmitter }
-export default EventEmitter;
+module.exports = EventEmitter;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
   "exports": {
     ".": {
-      "types": "./index.d.ts",
       "import": "./index.mjs",
       "require": "./index.js"
     },
@@ -24,6 +23,7 @@
     "index.js",
     "index.mjs",
     "index.d.ts",
+    "index.d.mts",
     "dist"
   ],
   "repository": {


### PR DESCRIPTION
Fixes another one of the issues reported by "Are The Types Wrong?":

Before:

<img width="1690" height="1105" alt="Screenshot 2025-11-19 at 1 27 37 PM" src="https://github.com/user-attachments/assets/87c4af4e-bb7a-4348-9e49-809d73ea96cc" />


After:
<img width="1690" height="1105" alt="Screenshot 2025-11-19 at 1 27 17 PM" src="https://github.com/user-attachments/assets/91c59a2c-a949-479b-8d2e-209e239a47a0" />
