### PR TITLE
Fix repository URL protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/primus/eventemitter3.git"
+    "url": "https://github.com/primus/eventemitter3.git"
   },
   "keywords": [
     "EventEmitter",


### PR DESCRIPTION
This updates the package metadata repository URL from the legacy `git://` protocol to HTTPS.

The `git://` protocol is unauthenticated and may be blocked on some networks, while the HTTPS GitHub URL is directly accessible to npm users and tooling.

Validation:
- Parsed `package.json` and asserted `repository.url`
- `git diff --check`
- `npm install --ignore-scripts`
- `npm test`

Note: `npm install` reports existing dependency audit warnings; this PR does not change dependencies or add a lockfile.